### PR TITLE
Add a `SetItem` function to `Inventory` and change types for `Inventory`

### DIFF
--- a/sdk/data.go
+++ b/sdk/data.go
@@ -10,21 +10,28 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/metric"
 )
 
-// Inventory is the data type for inventory data produced by a plugin data
+type inventoryItem map[string]interface{}
+
+// Inventory is the data type for inventory data produced by an integration data
 // source and emitted to the agent's inventory data store
-type Inventory map[string]interface{}
+type Inventory map[string]inventoryItem
+
+// SetItem stores a value into the inventory data structure
+func (i Inventory) SetItem(key string, field string, value interface{}) {
+	i[key] = inventoryItem{field: value}
+}
 
 // Event is the data type for single shot events
 type Event map[string]interface{}
 
 // Integration defines the format of the output JSON that plugins will return
 type Integration struct {
-	Name               string               `json:"name"`
-	ProtocolVersion    string               `json:"protocol_version"`
-	IntegrationVersion string               `json:"integration_version"`
-	Metrics            []*metric.MetricSet  `json:"metrics"`
-	Inventory          map[string]Inventory `json:"inventory"`
-	Events             []Event              `json:"events"`
+	Name               string              `json:"name"`
+	ProtocolVersion    string              `json:"protocol_version"`
+	IntegrationVersion string              `json:"integration_version"`
+	Metrics            []*metric.MetricSet `json:"metrics"`
+	Inventory          Inventory           `json:"inventory"`
+	Events             []Event             `json:"events"`
 	prettyOutput       bool
 }
 
@@ -47,7 +54,7 @@ func NewIntegration(name string, version string, arguments interface{}) (*Integr
 		Name:               name,
 		ProtocolVersion:    "1",
 		IntegrationVersion: version,
-		Inventory:          make(map[string]Inventory),
+		Inventory:          make(Inventory),
 		Metrics:            make([]*metric.MetricSet, 0),
 		Events:             make([]Event, 0),
 		prettyOutput:       defaultArgs.Pretty,


### PR DESCRIPTION
In the SDK protocol, the Inventory data structure is just a map of maps. With
this change, we "hide" this implementation adding `Inventory` and
`inventoryItem` structs, and we provide `SetItem` method to the sdk user to add
elements to the inventory of an integration.

#### Description of the changes

Add a detailed description and purpose of your changes.
Link the issue it solves (if there is one).

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
