### PR TITLE
[sdk] Allow to set multiple values for the same item for Inventory

### DIFF
--- a/sdk/data.go
+++ b/sdk/data.go
@@ -18,7 +18,12 @@ type Inventory map[string]inventoryItem
 
 // SetItem stores a value into the inventory data structure
 func (i Inventory) SetItem(key string, field string, value interface{}) {
-	i[key] = inventoryItem{field: value}
+	if _, ok := i[key]; ok {
+		i[key][field] = value
+	} else {
+		i[key] = inventoryItem{field: value}
+	}
+
 }
 
 // Event is the data type for single shot events

--- a/sdk/data_test.go
+++ b/sdk/data_test.go
@@ -151,15 +151,23 @@ func TestSetInventoryItem(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	pd.Inventory.SetItem("foo/bar", "value", "bar")
+	pd.Inventory.SetItem("foo/bar", "valueOne", "bar")
+	pd.Inventory.SetItem("foo/bar", "valueTwo", "bar")
 
 	if len(pd.Inventory) != 1 {
 		t.Error()
 	}
+	if len(pd.Inventory["foo/bar"]) != 2 {
+		t.Error()
+	}
 	expectedValue := "bar"
-	actualValue := pd.Inventory["foo/bar"]["value"]
+	actualValue := pd.Inventory["foo/bar"]["valueOne"]
 	if expectedValue != actualValue {
-		t.Errorf("For '%s' inventory item, the expected field '%s' is '%s'. Actual value: '%s'", "foo/bar", "value", expectedValue, actualValue)
+		t.Errorf("For '%s' inventory item, the expected field '%s' is '%s'. Actual value: '%s'", "foo/bar", "valueOne", expectedValue, actualValue)
+	}
+	actualValue = pd.Inventory["foo/bar"]["valueTwo"]
+	if expectedValue != actualValue {
+		t.Errorf("For '%s' inventory item, the expected field '%s' is '%s'. Actual value: '%s'", "foo/bar", "valueTwo", expectedValue, actualValue)
 	}
 }
 


### PR DESCRIPTION
#### Description of the changes
Change in the SetItem in order to allow to set multiple values for the same item for Inventory.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [x] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [x] approve the PR when you consider it's good to merge
