### PR TITLE
Remove `provider` argument to `NewMetricSet` function/method

### DIFF
--- a/metric/metrics.go
+++ b/metric/metrics.go
@@ -25,10 +25,9 @@ const (
 type MetricSet map[string]interface{}
 
 // NewMetricSet returns a new MetricSet instance
-func NewMetricSet(eventType string, provider string) MetricSet {
+func NewMetricSet(eventType string) MetricSet {
 	ms := MetricSet{}
 	ms.SetMetric("event_type", eventType, ATTRIBUTE)
-	ms.SetMetric("provider", provider, ATTRIBUTE)
 	return ms
 }
 

--- a/metric/metrics_test.go
+++ b/metric/metrics_test.go
@@ -43,7 +43,7 @@ func TestSetMetric(t *testing.T) {
 	fd := FakeData{}
 	cache.SetNow(fd.Now)
 
-	ms := metric.NewMetricSet("eventType", "provider")
+	ms := metric.NewMetricSet("eventType")
 
 	for _, tt := range metricTests {
 		ms.SetMetric(tt.key, tt.value, tt.metricType)

--- a/sdk/data.go
+++ b/sdk/data.go
@@ -69,8 +69,8 @@ func NewIntegration(name string, version string, arguments interface{}) (*Integr
 }
 
 // NewMetricSet returns a new instance of MetricSet with its sample attached to the IntegrationData
-func (integration *Integration) NewMetricSet(eventType string, provider string) *metric.MetricSet {
-	ms := metric.NewMetricSet(eventType, provider)
+func (integration *Integration) NewMetricSet(eventType string) *metric.MetricSet {
+	ms := metric.NewMetricSet(eventType)
 	integration.Metrics = append(integration.Metrics, &ms)
 	return &ms
 }

--- a/sdk/data_test.go
+++ b/sdk/data_test.go
@@ -45,12 +45,12 @@ func TestNewMetricSet(t *testing.T) {
 		t.Fatal()
 	}
 
-	metric1 := pd.NewMetricSet("TestPlugin", "TestProvider")
+	metric1 := pd.NewMetricSet("TestPlugin")
 	if metric1 != pd.Metrics[0] {
 		t.Error()
 	}
 
-	metric2 := pd.NewMetricSet("TestMetric2", "TestProvider2")
+	metric2 := pd.NewMetricSet("TestMetric2")
 	if metric2 != pd.Metrics[1] {
 		t.Error()
 	}


### PR DESCRIPTION
#### Description of the changes

We're going to recommend having specific EventTypes per integration instead of
having generic ones, and with that change the provider attribute isn't needed
anymore.

**Note:** This is a breaking change and we would need to update our integrations, and notify beta users about it.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
