### PR TITLE
[jmx] Adding timeout argument to the Query function

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -1,6 +1,6 @@
 /*
 Package jmx is a library to get metrics through JMX. It requires additional
-setup. Read https://github.com/newrelic/infra-integrations-sdk#JMX-SUPPORT for
+setup. Read https://github.com/newrelic/infra-integrations-sdk#jmx-support for
 instructions. */
 package jmx
 
@@ -27,8 +27,7 @@ var done sync.WaitGroup
 var jmxCommand = "/usr/bin/nrjmx"
 
 const (
-	outTimeout    time.Duration = 1000 * time.Millisecond
-	jmxLineBuffer               = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
+	jmxLineBuffer = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
 )
 
 func getCommand(hostname, port, username, password string) []string {
@@ -123,13 +122,13 @@ func doQuery(out chan []byte, errorChan chan error, queryString []byte) {
 	}
 }
 
-// Query returns a map with the attribute names and its values from the nrjmx
-// tool.
-func Query(objectPattern string) (map[string]interface{}, error) {
+// Query executes JMX query against nrjmx tool waiting up to timeout (in milliseconds)
+// and returns a map with the result.
+func Query(objectPattern string, timeout int) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	pipe := make(chan []byte)
 	queryErrors := make(chan error)
-
+	outTimeout := time.Duration(timeout) * time.Millisecond
 	// Send the query async to the underlying process so we can timeout it
 	go doQuery(pipe, queryErrors, []byte(fmt.Sprintf("%s\n", objectPattern)))
 

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -48,6 +48,8 @@ func TestMain(m *testing.M) {
 	}
 }
 
+const timeout = 1000
+
 func TestJmxOpen(t *testing.T) {
 	defer jmx.Close()
 
@@ -67,8 +69,8 @@ func TestJmxQuery(t *testing.T) {
 		t.Error()
 	}
 
-	if _, err := jmx.Query("empty"); err != nil {
-		t.Error()
+	if _, err := jmx.Query("empty", timeout); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -79,7 +81,7 @@ func TestJmxCrashQuery(t *testing.T) {
 		t.Error()
 	}
 
-	if _, err := jmx.Query("crash"); err == nil {
+	if _, err := jmx.Query("crash", timeout); err == nil {
 		t.Error()
 	}
 }
@@ -91,7 +93,7 @@ func TestJmxInvalidQuery(t *testing.T) {
 		t.Error()
 	}
 
-	if _, err := jmx.Query("invalid"); err == nil {
+	if _, err := jmx.Query("invalid", timeout); err == nil {
 		t.Error()
 	}
 }
@@ -103,12 +105,24 @@ func TestJmxTimeoutQuery(t *testing.T) {
 		t.Error()
 	}
 
-	if _, err := jmx.Query("timeout"); err == nil {
+	if _, err := jmx.Query("timeout", timeout); err == nil {
 		t.Error()
 	}
 
-	if _, err := jmx.Query("empty"); err == nil {
+	if _, err := jmx.Query("empty", timeout); err == nil {
 		t.Error()
+	}
+}
+
+func TestJmxNoTimeoutQuery(t *testing.T) {
+	defer jmx.Close()
+
+	if jmx.Open("", "", "", "") != nil {
+		t.Error()
+	}
+
+	if _, err := jmx.Query("timeout", 1500); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -119,11 +133,11 @@ func TestJmxTimeoutBigQuery(t *testing.T) {
 		t.Error()
 	}
 
-	if _, err := jmx.Query("bigPayload"); err != nil {
-		t.Error()
+	if _, err := jmx.Query("bigPayload", timeout); err != nil {
+		t.Error(err)
 	}
 
-	if _, err := jmx.Query("bigPayloadError"); err == nil {
+	if _, err := jmx.Query("bigPayloadError", timeout); err == nil {
 		t.Error()
 	}
 }


### PR DESCRIPTION
#### Description of the changes
Cassandra integration, which uses the JMX package, fails in some cases because some of the queries takes more time than 1s. Due to this we need to have a way to configure the timeout per each query.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [x] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [x] approve the PR when you consider it's good to merge
