### PR TITLE
[jmx] Ignore password and username arguments if empty 

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -39,10 +39,10 @@ func getCommand(hostname, port, username, password string) []string {
 		cliCommand = []string{jmxCommand}
 	}
 
-	cliCommand = append(
-		cliCommand, "--hostname", hostname, "--port", port,
-		"--username", username, "--password", password,
-	)
+	cliCommand = append(cliCommand, "--hostname", hostname, "--port", port)
+	if username != "" && password != "" {
+		cliCommand = append(cliCommand, "--username", username, "--password", password)
+	}
 
 	return cliCommand
 }


### PR DESCRIPTION
#### Description of the changes
Cassandra integration currently is failing if the customer doesn't specify password and username (so in case when JMX authentication is disable).

As a fix, in the function that composes the command sent to nrjmx tool we ignore password and username if they're empty. 

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
