### PR TITLE
Updated logrus to v1.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Protocol v2 support
 - Loggers can now be created from the log package.
 - Already created loggers can be configured from the log package.
+- Updated github.com/sirupsen/logrus dependency to v1.*
+### Fixed
+- github.com/Sirupsen/logrus is now github.com/sirupsen/logrus since v1.0.0.
 
 ## 2.0.0 (2017-10-11)
 ### Fixed

--- a/log/log.go
+++ b/log/log.go
@@ -3,7 +3,7 @@ package log
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // SetupLogging redirects logs to stderr and configures the log level.


### PR DESCRIPTION
#### Description of the changes

This code fixes the logrus version to `v1.*` since is the one we are using. 
This would be a BC for current users if they use an older version.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
