### PR TITLE
Downcase import line for logrus

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -3,7 +3,7 @@ package log
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // SetupLogging redirects logs to stderr and configures the log level.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -3,7 +3,7 @@ package log
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func TestSetupLogging(t *testing.T) {


### PR DESCRIPTION
Here we downcase import line for logrus to avoid an issue where go get tries to
include a package by the same name, but lowercased and fails.  This comes up as
part of including logrus in another project, where we want to use this SDK and
can't duplicate the logrus package with capitalizing our import.

I think the general case here is to have the package name downcased, even though
github works with either.

#### Description of the changes

Add a detailed description and purpose of your changes.
Link the issue it solves (if there is one).

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
