### PR TITLE
Decouple logger

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -42,7 +42,7 @@ func NewCache(l log.Logger) (*Cache, error) {
 	if cachePath == "" {
 		_, fname := filepath.Split(os.Args[0])
 		cachePath = filepath.Join(os.TempDir(), fmt.Sprintf("%s.json", fname))
-		l.Info("environment variable NRIA_CACHE_PATH is not set, using default %s", cachePath)
+		l.Infof("environment variable NRIA_CACHE_PATH is not set, using default %s", cachePath)
 	}
 
 	cache.path = cachePath
@@ -62,13 +62,13 @@ func NewCache(l log.Logger) (*Cache, error) {
 	}
 
 	if now().Sub(stat.ModTime()) > cacheTTL {
-		l.Info("cache file (%s) is older than %v, skipping loading from disk.", cachePath, cacheTTL)
+		l.Infof("cache file (%s) is older than %v, skipping loading from disk.", cachePath, cacheTTL)
 		return cache, nil
 	}
 
 	file, err := ioutil.ReadFile(cache.path)
 	if err != nil {
-		l.Info("cache file (%s) cannot be open for reading.", cachePath)
+		l.Infof("cache file (%s) cannot be open for reading.", cachePath)
 		return cache, nil
 	}
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -32,7 +32,7 @@ type Cache struct {
 // NewCache will create and initialize a DiskCache object. It expects the
 // NRIA_CACHE_PATH environment variable to point to the file with the cache. If
 // it is not set, this will act as a memory-only cache.
-func NewCache() (*Cache, error) {
+func NewCache(l log.Logger) (*Cache, error) {
 	cache := &Cache{
 		Data:       make(map[string]interface{}),
 		Timestamps: make(map[string]int64),
@@ -42,7 +42,7 @@ func NewCache() (*Cache, error) {
 	if cachePath == "" {
 		_, fname := filepath.Split(os.Args[0])
 		cachePath = filepath.Join(os.TempDir(), fmt.Sprintf("%s.json", fname))
-		log.Warn("environment variable NRIA_CACHE_PATH is not set, using default %s", cachePath)
+		l.Info("environment variable NRIA_CACHE_PATH is not set, using default %s", cachePath)
 	}
 
 	cache.path = cachePath
@@ -62,13 +62,13 @@ func NewCache() (*Cache, error) {
 	}
 
 	if now().Sub(stat.ModTime()) > cacheTTL {
-		log.Warn("cache file (%s) is older than %v, skipping loading from disk.", cachePath, cacheTTL)
+		l.Info("cache file (%s) is older than %v, skipping loading from disk.", cachePath, cacheTTL)
 		return cache, nil
 	}
 
 	file, err := ioutil.ReadFile(cache.path)
 	if err != nil {
-		log.Warn("cache file (%s) cannot be open for reading.", cachePath)
+		l.Info("cache file (%s) cannot be open for reading.", cachePath)
 		return cache, nil
 	}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -20,14 +20,14 @@ func TestDiskCache(t *testing.T) {
 
 	// Create cache with existing file in env
 	os.Setenv("NRIA_CACHE_PATH", file.Name())
-	_, err = cache.NewCache()
+	_, err = cache.NewCache(cache.GlobalLog)
 	if err != nil {
 		t.Error()
 	}
 
 	// Create cache with unexisting file in env
 	os.Setenv("NRIA_CACHE_PATH", "newfile.json")
-	_, err = cache.NewCache()
+	_, err = cache.NewCache(cache.GlobalLog)
 	defer os.Remove("newfile.json")
 	if err != nil {
 		t.Error()
@@ -35,7 +35,7 @@ func TestDiskCache(t *testing.T) {
 
 	// Create cache with default file
 	os.Setenv("NRIA_CACHE_PATH", "")
-	dc, err := cache.NewCache()
+	dc, err := cache.NewCache(cache.GlobalLog)
 	if err != nil {
 		t.Fail()
 	}
@@ -55,7 +55,7 @@ func TestCacheSet(t *testing.T) {
 	os.Setenv("NRIA_CACHE_PATH", "")
 	curdir, _ := os.Getwd()
 
-	dc, err := cache.NewCache()
+	dc, err := cache.NewCache(cache.GlobalLog)
 	defer os.Remove(curdir + "/cache.json")
 
 	if err != nil {
@@ -76,7 +76,7 @@ func TestCacheGet(t *testing.T) {
 	os.Setenv("NRIA_CACHE_PATH", "")
 	curdir, _ := os.Getwd()
 
-	dc, err := cache.NewCache()
+	dc, err := cache.NewCache(cache.GlobalLog)
 	defer os.Remove(curdir + "/cache.json")
 
 	if err != nil {
@@ -115,7 +115,7 @@ func TestCacheSave(t *testing.T) {
 	os.Setenv("NRIA_CACHE_PATH", "cache.json")
 	curdir, _ := os.Getwd()
 
-	dc, err := cache.NewCache()
+	dc, err := cache.NewCache(cache.GlobalLog)
 	defer os.Remove(curdir + "/cache.json")
 
 	if err != nil {
@@ -130,7 +130,7 @@ func TestCacheSave(t *testing.T) {
 		t.Error()
 	}
 
-	dc, err = cache.NewCache()
+	dc, err = cache.NewCache(cache.GlobalLog)
 	if err != nil {
 		t.Fail()
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,33 +1,30 @@
-package cache_test
+package cache
 
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/newrelic/infra-integrations-sdk/cache"
 )
 
 func TestDiskCache(t *testing.T) {
 	file, err := ioutil.TempFile("", "cache")
 	if err != nil {
-		log.Fatal("Can't create temporary cache file")
+		t.Error("Can't create temporary cache file")
 	}
 	defer os.Remove(file.Name())
 
 	// Create cache with existing file in env
 	os.Setenv("NRIA_CACHE_PATH", file.Name())
-	_, err = cache.NewCache(cache.GlobalLog)
+	_, err = NewCache(GlobalLog)
 	if err != nil {
 		t.Error()
 	}
 
 	// Create cache with unexisting file in env
 	os.Setenv("NRIA_CACHE_PATH", "newfile.json")
-	_, err = cache.NewCache(cache.GlobalLog)
+	_, err = NewCache(GlobalLog)
 	defer os.Remove("newfile.json")
 	if err != nil {
 		t.Error()
@@ -35,7 +32,7 @@ func TestDiskCache(t *testing.T) {
 
 	// Create cache with default file
 	os.Setenv("NRIA_CACHE_PATH", "")
-	dc, err := cache.NewCache(cache.GlobalLog)
+	dc, err := NewCache(GlobalLog)
 	if err != nil {
 		t.Fail()
 	}
@@ -55,8 +52,8 @@ func TestCacheSet(t *testing.T) {
 	os.Setenv("NRIA_CACHE_PATH", "")
 	curdir, _ := os.Getwd()
 
-	dc, err := cache.NewCache(cache.GlobalLog)
-	defer os.Remove(curdir + "/cache.json")
+	dc, err := NewCache(GlobalLog)
+	defer os.Remove(curdir + "/json")
 
 	if err != nil {
 		t.Fatal()
@@ -76,8 +73,8 @@ func TestCacheGet(t *testing.T) {
 	os.Setenv("NRIA_CACHE_PATH", "")
 	curdir, _ := os.Getwd()
 
-	dc, err := cache.NewCache(cache.GlobalLog)
-	defer os.Remove(curdir + "/cache.json")
+	dc, err := NewCache(GlobalLog)
+	defer os.Remove(curdir + "/json")
 
 	if err != nil {
 		t.Fatal()
@@ -112,11 +109,11 @@ func TestCacheGet(t *testing.T) {
 
 func TestCacheSave(t *testing.T) {
 	// Create cache with default file
-	os.Setenv("NRIA_CACHE_PATH", "cache.json")
+	os.Setenv("NRIA_CACHE_PATH", "json")
 	curdir, _ := os.Getwd()
 
-	dc, err := cache.NewCache(cache.GlobalLog)
-	defer os.Remove(curdir + "/cache.json")
+	dc, err := NewCache(GlobalLog)
+	defer os.Remove(curdir + "/json")
 
 	if err != nil {
 		t.Fail()
@@ -130,7 +127,7 @@ func TestCacheSave(t *testing.T) {
 		t.Error()
 	}
 
-	dc, err = cache.NewCache(cache.GlobalLog)
+	dc, err = NewCache(GlobalLog)
 	if err != nil {
 		t.Fail()
 	}

--- a/cache/global.go
+++ b/cache/global.go
@@ -1,6 +1,18 @@
 package cache
 
-var instance, err = NewCache()
+import "github.com/newrelic/infra-integrations-sdk/log"
+
+// DefaultDebug default debug mode for the cache.
+const DefaultDebug = false
+
+// TODO delete when removing these globals
+var GlobalLog = log.NewStdErr(DefaultDebug)
+
+var instance, err = NewCache(GlobalLog)
+
+func SetupLogging(verbose bool) {
+	GlobalLog.SetDebug(verbose)
+}
 
 // Save marshalls and stores the data the cache is holding into disk as a JSON file.
 func Save() error {

--- a/docs/tutorial-code/redis.go
+++ b/docs/tutorial-code/redis.go
@@ -126,7 +126,7 @@ func main() {
 	if args.All || args.Events {
 		err := populateEvents(integration)
 		if err != nil {
-			cache.GlobalLog.Debug("adding event failed, got: %s", err)
+			cache.GlobalLog.Debugf("adding event failed, got: %s", err)
 		}
 	}
 	panicOnErr(integration.Publish())

--- a/docs/tutorial-code/redis.go
+++ b/docs/tutorial-code/redis.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
-	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/metric"
 	"github.com/newrelic/infra-integrations-sdk/sdk/v1"
+	"github.com/newrelic/infra-integrations-sdk/cache"
 )
 
 type argumentList struct {
@@ -112,28 +112,28 @@ func populateEvents(integration *v1.Integration) error {
 
 func main() {
 	integration, err := v1.NewIntegration(integrationName, integrationVersion, &args)
-	fatalIfErr(err)
+	panicOnErr(err)
 
 	if args.All || args.Inventory {
-		fatalIfErr(populateInventory(integration.Inventory))
+		panicOnErr(populateInventory(integration.Inventory))
 	}
 
 	if args.All || args.Metrics {
 		ms := integration.NewMetricSet("RedisSample")
-		fatalIfErr(populateMetrics(&ms))
+		panicOnErr(populateMetrics(&ms))
 	}
 
 	if args.All || args.Events {
 		err := populateEvents(integration)
 		if err != nil {
-			log.Debug("adding event failed, got: %s", err)
+			cache.GlobalLog.Debug("adding event failed, got: %s", err)
 		}
 	}
-	fatalIfErr(integration.Publish())
+	panicOnErr(integration.Publish())
 }
 
-func fatalIfErr(err error) {
+func panicOnErr(err error) {
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Logger interface {
-	Debug(format string, args ...interface{})
-	Info(format string, args ...interface{})
-	Error(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
 	SetDebug(enable bool) // deprecated TODO remove when deleting global scope from cache
 }
 
@@ -32,20 +32,20 @@ func New(debug bool, w io.Writer) Logger {
 	}
 }
 
-// Debug logs a formatted message at level Debug.
-func (l *defaultLogger) Debug(format string, args ...interface{}) {
+// Debugf logs a formatted message at level Debug.
+func (l *defaultLogger) Debugf(format string, args ...interface{}) {
 	if l.debug {
 		l.prefixPrint("DEBUG", format, args)
 	}
 }
 
-// Info logs a formatted message at level Info.
-func (l *defaultLogger) Info(format string, args ...interface{}) {
+// Infof logs a formatted message at level Info.
+func (l *defaultLogger) Infof(format string, args ...interface{}) {
 	l.prefixPrint("INFO", format, args)
 }
 
-// Error logs a formatted message at level Error.
-func (l *defaultLogger) Error(format string, args ...interface{}) {
+// Errorf logs a formatted message at level Error.
+func (l *defaultLogger) Errorf(format string, args ...interface{}) {
 	l.prefixPrint("ERR", format, args)
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -11,6 +11,7 @@ type Logger interface {
 	Debug(format string, args ...interface{})
 	Info(format string, args ...interface{})
 	Error(format string, args ...interface{})
+	SetDebug(enable bool) // deprecated TODO remove when deleting global scope from cache
 }
 
 type defaultLogger struct {
@@ -53,4 +54,9 @@ func (l *defaultLogger) prefixPrint(prefix string, format string, args ...interf
 	log.SetPrefix(prefix)
 	l.logger.Printf(format, args...)
 	log.SetPrefix(prev)
+}
+
+// deprecated TODO remove when deleting global scope from cache
+func (l *defaultLogger) SetDebug(enable bool) {
+	l.debug = enable
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -15,8 +15,8 @@ func TestNew(t *testing.T) {
 	l := New(false, &writer)
 
 
-	l.Error("foo")
-	l.Error("bar")
+	l.Errorf("foo")
+	l.Errorf("bar")
 
 	logged := writer.String()
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,56 +1,29 @@
 package log
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"bytes"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestSetupLogging(t *testing.T) {
-	SetupLogging(false)
-	if logrus.GetLevel() != logrus.InfoLevel {
-		t.Error("level should be info when verbose is false")
-	}
-
-	SetupLogging(true)
-	if logrus.GetLevel() != logrus.DebugLevel {
-		t.Error("level should be debug when verbose is true")
-	}
-}
-
-func TestConfigureLogger(t *testing.T) {
-	l := logrus.New()
-	l.Out = ioutil.Discard
-
-	ConfigureLogger(l, false)
-	if l.Level != logrus.InfoLevel {
-		t.Error("level should be info when verbose is false")
-	}
-
-	ConfigureLogger(l, true)
-	if l.Level != logrus.DebugLevel {
-		t.Error("level should be debug when verbose is true")
-	}
-
-	if l.Out != os.Stderr {
-		t.Error("logger out should be stderr")
-	}
-}
-
 func TestNew(t *testing.T) {
-	l := New(false)
-	if l.Level != logrus.InfoLevel {
-		t.Error("level should be info when verbose is false")
-	}
+	var writer bytes.Buffer
 
-	l = New(true)
-	if l.Level != logrus.DebugLevel {
-		t.Error("level should be debug when verbose is true")
-	}
+	l := New(false, &writer)
 
-	if l.Out != os.Stderr {
-		t.Error("logger out should be stderr")
-	}
+
+	l.Error("foo")
+	l.Error("bar")
+
+	logged := writer.String()
+
+	assert.True(t, strings.Contains(logged, "foo"))
+	assert.True(t, strings.Contains(logged, "bar"))
+	assert.Equal(t, 2, strings.Count(logged, "\n"), "should add carriage return on each error")
+
+	// show log on verbose
+	t.Log(logged)
 }

--- a/sdk/v1/data.go
+++ b/sdk/v1/data.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/cache"
-	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/metric"
 )
 
@@ -58,7 +57,7 @@ func NewIntegration(name string, version string, arguments interface{}) (*Integr
 	}
 	defaultArgs := args.GetDefaultArgs(arguments)
 
-	log.SetupLogging(defaultArgs.Verbose)
+	cache.GlobalLog.SetDebug(defaultArgs.Verbose)
 
 	// Avoid working with an uninitialized or in error state cache
 	if err = cache.Status(); err != nil {

--- a/sdk/v2/data.go
+++ b/sdk/v2/data.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/cache"
-	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/metric"
 	"github.com/newrelic/infra-integrations-sdk/sdk/v1"
 	"github.com/pkg/errors"
@@ -93,7 +92,7 @@ func NewIntegration(name string, version string, arguments interface{}) (*Integr
 	}
 	defaultArgs := args.GetDefaultArgs(arguments)
 
-	log.SetupLogging(defaultArgs.Verbose)
+	cache.GlobalLog.SetDebug(defaultArgs.Verbose)
 
 	// Avoid working with an uninitialized or in error state cache
 	if err = cache.Status(); err != nil {


### PR DESCRIPTION
#### Description of the changes

1. Decouples logger from `logrus` via `interface` extraction and `Writer` injection.
2. Its default implementation uses Go builtin component.

A further refactor on global cache is required to remove `deprecated` `SetDebug(bool)` method.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
