### PR TITLE
Fix JMX race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,19 @@ GOTOOLS = github.com/golang/lint/golint \
           github.com/AlekSi/gocov-xml \
 
 # Temporary patch to avoid build failing because of the outdated documentation example
+# TODO: uncomment below commented lines and remove any line that uses $(NODOCS)
 NODOCS = $(shell go list ./... | grep -v /docs/)
+PKGS = $(shell go list ./... | egrep -v "\/docs\/|jmx")
 
 all: lint test
 
 deps: tools
+#	@go get -v -d -t ./...
 	@go get -v -d -t $(NODOCS) #TODO: remove
 
 test: deps
-	@gocov test -race $(NODOCS) | gocov-xml > coverage.xml
+	@gocov test github.com/newrelic/infra-integrations-sdk/jmx > /dev/null # TODO: fix race for jmx package
+	@gocov test -race $(PKGS) | gocov-xml > coverage.xml
 
 clean:
 	rm -rf coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,15 @@ GOTOOLS = github.com/golang/lint/golint \
           github.com/AlekSi/gocov-xml \
 
 # Temporary patch to avoid build failing because of the outdated documentation example
-# TODO: uncomment below commented lines and remove any line that uses $(NODOCS)
 NODOCS = $(shell go list ./... | grep -v /docs/)
-PKGS = $(shell go list ./... | egrep -v "\/docs\/|jmx")
 
 all: lint test
 
 deps: tools
-#	@go get -v -d -t ./...
 	@go get -v -d -t $(NODOCS) #TODO: remove
 
 test: deps
-	@gocov test github.com/newrelic/infra-integrations-sdk/jmx > /dev/null # TODO: fix race for jmx package
-	@gocov test -race $(PKGS) | gocov-xml > coverage.xml
+	@gocov test -race $(NODOCS) | gocov-xml > coverage.xml
 
 clean:
 	rm -rf coverage.xml

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -1,13 +1,13 @@
 package integration
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/data/inventory"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/persist"
-	"github.com/pkg/errors"
 )
 
 // Entity is the producer of the data. Entity could be a host, a container, a pod, or whatever unit of meaning.

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/persist"
-	"github.com/pkg/errors"
 )
 
 const protocolVersion = "2"
@@ -156,7 +156,7 @@ func (i *Integration) Clear() {
 func (i *Integration) MarshalJSON() (output []byte, err error) {
 	output, err = json.Marshal(*i)
 	if err != nil {
-		err = errors.Wrap(err, "error marshalling to JSON")
+		err = fmt.Errorf("error marshalling to JSON: %s", err)
 	}
 
 	return

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -70,8 +70,6 @@ func Open(hostname, port, username, password string) error {
 	cliCommand := getCommand(hostname, port, username, password)
 
 	ctx, cancel = context.WithCancel(context.Background())
-	// Avoid stupid errors/warnings b/c cancel is not used in this method
-	_ = cancel
 
 	cmd = exec.CommandContext(ctx, cliCommand[0], cliCommand[1:]...)
 
@@ -109,9 +107,8 @@ func Close() {
 		return
 	}
 
-	cmdIn.Close()
-	// nolint: errcheck
 	cancel()
+	_ = cmdIn.Close()
 	done.Wait()
 }
 

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -17,6 +17,7 @@ import (
 	"time"
 )
 
+var lock sync.Mutex
 var cmd *exec.Cmd
 var cancel context.CancelFunc
 var cmdOut io.ReadCloser
@@ -49,6 +50,9 @@ func getCommand(hostname, port, username, password string) []string {
 
 // Open will start the nrjmx command with the provided connection parameters.
 func Open(hostname, port, username, password string) error {
+	lock.Lock()
+	defer lock.Unlock()
+
 	if cmd != nil {
 		return fmt.Errorf("JMX tool is already running with PID: %d", cmd.Process.Pid)
 	}
@@ -86,6 +90,9 @@ func Open(hostname, port, username, password string) error {
 			cmdErr <- fmt.Errorf("JMX tool exited with error: %s", err)
 		}
 		done.Done()
+
+		lock.Lock()
+		defer lock.Unlock()
 		cmd = nil
 	}()
 
@@ -95,26 +102,38 @@ func Open(hostname, port, username, password string) error {
 // Close will finish the underlying nrjmx application by closing its standard
 // input and canceling the execution afterwards to clean-up.
 func Close() {
+	lock.Lock()
+	defer lock.Unlock()
+
 	if cmd == nil {
 		return
 	}
 
-	cmdIn.Close() // nolint: errcheck
+	cmdIn.Close()
+	// nolint: errcheck
 	cancel()
 	done.Wait()
 }
 
-func doQuery(out chan []byte, errorChan chan error, queryString []byte) {
+func doQuery(ctx context.Context, out chan []byte, errorChan chan error, queryString []byte) {
+	lock.Lock()
 	if _, err := cmdIn.Write(queryString); err != nil {
+		lock.Unlock()
 		errorChan <- fmt.Errorf("writing query string: %s", err.Error())
 		return
 	}
 
 	scanner := bufio.NewScanner(cmdOut)
 	scanner.Buffer([]byte{}, jmxLineBuffer) // Override default buffer to increase buffer size
+	lock.Unlock()
 
 	if scanner.Scan() {
-		out <- scanner.Bytes()
+		select {
+		case <-ctx.Done():
+			return
+		case out <- scanner.Bytes():
+		default:
+		}
 	} else {
 		if err := scanner.Err(); err != nil {
 			errorChan <- fmt.Errorf("error reading output from JMX tool: %v", err)
@@ -128,16 +147,19 @@ func doQuery(out chan []byte, errorChan chan error, queryString []byte) {
 // Query executes JMX query against nrjmx tool waiting up to timeout (in milliseconds)
 // and returns a map with the result.
 func Query(objectPattern string, timeout int) (map[string]interface{}, error) {
+	ctx, cancelFn := context.WithCancel(context.Background())
+
 	result := make(map[string]interface{})
-	pipe := make(chan []byte)
+	lineCh := make(chan []byte, jmxLineBuffer*2)
 	queryErrors := make(chan error)
 	outTimeout := time.Duration(timeout) * time.Millisecond
 	// Send the query async to the underlying process so we can timeout it
-	go doQuery(pipe, queryErrors, []byte(fmt.Sprintf("%s\n", objectPattern)))
+	go doQuery(ctx, lineCh, queryErrors, []byte(fmt.Sprintf("%s\n", objectPattern)))
 
 	select {
-	case line := <-pipe:
+	case line := <-lineCh:
 		if line == nil {
+			cancelFn()
 			Close()
 			return nil, fmt.Errorf("got empty result for query: %s", objectPattern)
 		}
@@ -150,6 +172,7 @@ func Query(objectPattern string, timeout int) (map[string]interface{}, error) {
 		return nil, err
 	case <-time.After(outTimeout):
 		// In case of timeout, we want to close the command to avoid mixing up results coming up latter
+		cancelFn()
 		Close()
 		return nil, fmt.Errorf("timeout while waiting for query: %s", objectPattern)
 	}

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 var lock sync.Mutex

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -65,8 +65,8 @@ func TestJmxOpen(t *testing.T) {
 func TestJmxQuery(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := jmx.Query("empty", timeout); err != nil {

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -53,8 +53,8 @@ const timeout = 1000
 func TestJmxOpen(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if jmx.Open("", "", "", "") == nil {
@@ -77,8 +77,8 @@ func TestJmxQuery(t *testing.T) {
 func TestJmxCrashQuery(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := jmx.Query("crash", timeout); err == nil {
@@ -89,8 +89,8 @@ func TestJmxCrashQuery(t *testing.T) {
 func TestJmxInvalidQuery(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := jmx.Query("invalid", timeout); err == nil {
@@ -101,8 +101,8 @@ func TestJmxInvalidQuery(t *testing.T) {
 func TestJmxTimeoutQuery(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := jmx.Query("timeout", timeout); err == nil {
@@ -117,8 +117,8 @@ func TestJmxTimeoutQuery(t *testing.T) {
 func TestJmxNoTimeoutQuery(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := jmx.Query("timeout", 1500); err != nil {
@@ -129,8 +129,8 @@ func TestJmxNoTimeoutQuery(t *testing.T) {
 func TestJmxTimeoutBigQuery(t *testing.T) {
 	defer jmx.Close()
 
-	if jmx.Open("", "", "", "") != nil {
-		t.Error()
+	if err := jmx.Open("", "", "", ""); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := jmx.Query("bigPayload", timeout); err != nil {

--- a/persist/storer.go
+++ b/persist/storer.go
@@ -2,6 +2,7 @@ package persist
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"

--- a/persist/storer.go
+++ b/persist/storer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/newrelic/infra-integrations-sdk/log"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -98,7 +97,7 @@ func NewFileStore(storePath string, l log.Logger) (Storer, error) {
 	// Store file doesn't exist yet
 	if err != nil {
 		if _, err = os.OpenFile(store.path, os.O_CREATE|os.O_WRONLY, filePerm); err != nil {
-			return nil, errors.Errorf("store directory not writable: %s", storeDir)
+			return nil, fmt.Errorf("store directory not writable: %s", storeDir)
 		}
 		return store, nil
 	}


### PR DESCRIPTION
Fix JMX race conditions:
* locks on data (enables concurrency)
* cancels query context on:
  - timeout
  - empty query output

If query goroutine is not stopped, it could possible lock the integration in a `defunct` state (orphaned goroutine keeping the `nrjmx` alive).

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
