### PR TITLE
Cache collision fix

### DIFF
--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -14,10 +14,10 @@ import (
 // each one.
 type SourceType int
 
-// group identifies a metric group
-type group struct {
-	field string
-	value string
+// KV represents a metric key-value pair.
+type KV struct {
+	Key   string
+	Value string
 }
 
 const (
@@ -43,28 +43,28 @@ var (
 type Set struct {
 	storer  persist.Storer
 	Metrics map[string]interface{}
-	group   group
+	id      []KV
 }
 
-// NewSet creates new metrics set.
-func NewSet(eventType string, storer persist.Storer) (*Set, error) {
-	return NewSetGroup(eventType, storer, "", "")
-}
-
-// NewSetGroup creates a metrics set that will attach all the metrics to the given field-value.
-func NewSetGroup(eventType string, storer persist.Storer, field, value string) (*Set, error) {
+// NewSet creates new metrics set, optionally identified by a list of key-values.
+func NewSet(eventType string, storer persist.Storer, kv ...KV) (*Set, error) {
 	ms := Set{
 		Metrics: make(map[string]interface{}),
 		storer:  storer,
-		group: group{
-			field: field,
-			value: value,
-		},
+		id:      kv,
 	}
 
 	err := ms.SetMetric("event_type", eventType, ATTRIBUTE)
 
 	return &ms, err
+}
+
+// NewKV creates a new KV pair.
+func NewKV(key string, value string) KV {
+	return KV{
+		Key:   key,
+		Value: value,
+	}
 }
 
 // SetMetric adds a metric to the Set object or updates the metric value if the metric already exists.

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -173,13 +173,7 @@ func (ms *Set) namespace(metricName string) string {
 	separator := ""
 
 	attrs := ms.nsAttributes
-	sort.Slice(attrs, func(i, j int) bool {
-		if attrs[i].Key == attrs[j].Key {
-			return attrs[i].Value < attrs[j].Value
-		}
-
-		return attrs[i].Key < attrs[j].Key
-	})
+	sort.Sort(Attributes(attrs))
 
 	for _, attr := range attrs {
 		ns = fmt.Sprintf("%s%s%s", ns, separator, attr.Namespace())
@@ -197,4 +191,23 @@ func (a *Attribute) Namespace() string {
 // MarshalJSON adapts the internal structure of the metrics Set to the payload that is compliant with the protocol
 func (ms Set) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ms.Metrics)
+}
+
+// Required for Go < v.18, as these do not include sort.Slice
+
+// Attributes list of attributes
+type Attributes []Attribute
+
+// Len ...
+func (a Attributes) Len() int { return len(a) }
+
+// Swap ...
+func (a Attributes) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// Less ...
+func (a Attributes) Less(i, j int) bool {
+	if a[i].Key == a[j].Key {
+		return a[i].Value < a[j].Value
+	}
+	return a[i].Key < a[j].Key
 }

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -85,8 +85,6 @@ func Attr(key string, value string) Attribute {
 
 // SetMetric adds a metric to the Set object or updates the metric value if the metric already exists.
 // It calculates elapsed difference for RATE and DELTA types.
-// ErrDeltaWithNoAttrs error is returned as a warning if a RATE or DELTA is used and the metric-set does not contain
-// any Attribute.
 func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) (err error) {
 	var errElapsed error
 	var newValue = value
@@ -96,6 +94,7 @@ func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) 
 	case RATE, DELTA:
 		if len(ms.nsAttributes) == 0 {
 			err = ErrDeltaWithNoAttrs
+			return
 		}
 		newValue, errElapsed = ms.elapsedDifference(name, value, sourceType)
 		if errElapsed != nil {

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -49,18 +49,18 @@ var (
 
 // Set is the basic structure for storing metrics.
 type Set struct {
-	storer    persist.Storer
-	Metrics   map[string]interface{}
-	relatedTo []Attribute
+	storer       persist.Storer
+	Metrics      map[string]interface{}
+	nsAttributes []Attribute
 }
 
 // NewSet creates new metrics set, optionally related to a list of attributes.
 // If related attributes are used, then a new attribute-metric is added per kv-pair.
-func NewSet(eventType string, storer persist.Storer, relatedTo ...Attribute) (s *Set, err error) {
+func NewSet(eventType string, storer persist.Storer, nsAttributes ...Attribute) (s *Set, err error) {
 	s = &Set{
-		Metrics:   make(map[string]interface{}),
-		storer:    storer,
-		relatedTo: relatedTo,
+		Metrics:      make(map[string]interface{}),
+		storer:       storer,
+		nsAttributes: nsAttributes,
 	}
 
 	err = s.SetMetric("event_type", eventType, ATTRIBUTE)
@@ -68,7 +68,7 @@ func NewSet(eventType string, storer persist.Storer, relatedTo ...Attribute) (s 
 		return
 	}
 
-	for _, attr := range relatedTo {
+	for _, attr := range nsAttributes {
 		err = s.SetMetric(attr.Key, attr.Value, ATTRIBUTE)
 		if err != nil {
 			return
@@ -78,8 +78,8 @@ func NewSet(eventType string, storer persist.Storer, relatedTo ...Attribute) (s 
 	return
 }
 
-// RelatedTo creates an attribute for a metric-set to be related to.
-func RelatedTo(key string, value string) Attribute {
+// Attr creates an attribute aimed to namespace a metric-set.
+func Attr(key string, value string) Attribute {
 	return Attribute{
 		Key:   key,
 		Value: value,
@@ -172,7 +172,7 @@ func (ms *Set) namespace(metricName string) string {
 	ns := ""
 	separator := ""
 
-	attrs := ms.relatedTo
+	attrs := ms.nsAttributes
 	sort.Slice(attrs, func(i, j int) bool {
 		if attrs[i].Key == attrs[j].Key {
 			return attrs[i].Value < attrs[j].Value

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -33,16 +33,16 @@ const (
 )
 
 const (
-	// NSSeparator is the metric namespace separator
-	NSSeparator = "::"
-	// NSAttributeSeparator is the metric attribute key-value separator applied to generate the metric ns.
-	NSAttributeSeparator = "=="
+	// nsSeparator is the metric namespace separator
+	nsSeparator = "::"
+	// nsAttributeSeparator is the metric attribute key-value separator applied to generate the metric ns.
+	nsAttributeSeparator = "=="
 )
 
 // Errors
 var (
 	ErrNonNumeric        = errors.New("non-numeric value for rate/delta")
-	ErrNoStoreToCalcDiff = errors.New("can't use deltas nor rates without persistent store")
+	ErrNoStoreToCalcDiff = errors.New("cannot use deltas nor rates without persistent store")
 	ErrTooCloseSamples   = errors.New("samples too close in time, skipping")
 	ErrNegativeDiff      = errors.New("source was reset, skipping")
 )
@@ -177,7 +177,7 @@ func (ms *Set) namespace(metricName string) string {
 
 	for _, attr := range attrs {
 		ns = fmt.Sprintf("%s%s%s", ns, separator, attr.Namespace())
-		separator = NSSeparator
+		separator = nsSeparator
 	}
 
 	return fmt.Sprintf("%s%s%s", ns, separator, metricName)
@@ -185,7 +185,7 @@ func (ms *Set) namespace(metricName string) string {
 
 // Namespace generates the string value of an attribute used to namespace a metric.
 func (a *Attribute) Namespace() string {
-	return fmt.Sprintf("%s%s%s", a.Key, NSAttributeSeparator, a.Value)
+	return fmt.Sprintf("%s%s%s", a.Key, nsAttributeSeparator, a.Value)
 }
 
 // MarshalJSON adapts the internal structure of the metrics Set to the payload that is compliant with the protocol

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -25,6 +25,14 @@ const (
 	ATTRIBUTE SourceType = iota
 )
 
+// Errors
+var (
+	ErrNonNumeric        = errors.New("non-numeric value for rate/delta")
+	ErrNoStoreToCalcDiff = errors.New("can't use deltas nor rates without persistent store")
+	ErrTooCloseSamples   = errors.New("samples too close in time, skipping")
+	ErrSameOldValue      = errors.New("source was reset, skipping")
+)
+
 // Set is the basic structure for storing metrics.
 type Set struct {
 	storer  persist.Storer
@@ -43,9 +51,8 @@ func NewSet(eventType string, storer persist.Storer) (*Set, error) {
 	return &ms, err
 }
 
-// SetMetric adds a metric to the Set object or updates the metric value
-// if the metric already exists, performing a calculation if the SourceType
-// (RATE, DELTA) requires it.
+// SetMetric adds a metric to the Set object or updates the metric value if the metric already exists.
+// It calculates elapsed difference for RATE and DELTA types.
 func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) error {
 	var err error
 	var newValue = value
@@ -53,20 +60,12 @@ func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) 
 	// Only sample metrics of numeric type
 	switch sourceType {
 	case RATE, DELTA:
-		if ms.storer == nil {
-			// This will only happen if the user explicitly builds the integration invoking 'NoCache' function
-			return fmt.Errorf("integrations built with no-store can't use DELTAs and RATEs")
-		}
-		floatVal, err := castToNumeric(value)
+		newValue, err = ms.elapsedDifference(name, value, sourceType)
 		if err != nil {
-			return fmt.Errorf("non-numeric value for rate/delta metric: %s value: %v", name, value)
-		}
-		newValue, err = ms.sample(name, floatVal, sourceType)
-		if err != nil {
-			return err
+			return errors.Wrapf(err, "cannot calculate elapsed difference for metric: %s value %v", name, value)
 		}
 	case GAUGE:
-		newValue, err = castToNumeric(value)
+		newValue, err = castToFloat(value)
 		if err != nil {
 			return fmt.Errorf("non-numeric value for gauge metric: %s value: %v", name, value)
 		}
@@ -82,41 +81,55 @@ func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) 
 	return nil
 }
 
-func castToNumeric(value interface{}) (float64, error) {
+func castToFloat(value interface{}) (float64, error) {
 	return strconv.ParseFloat(fmt.Sprintf("%v", value), 64)
 }
 
-func (ms *Set) sample(name string, floatValue float64, sourceType SourceType) (float64, error) {
-	sampledValue := 0.0
+func (ms *Set) elapsedDifference(name string, absolute interface{}, sourceType SourceType) (elapsed float64, err error) {
+	if ms.storer == nil {
+		err = ErrNoStoreToCalcDiff
+		return
+	}
 
-	// Retrieve the last value and timestamp from Storer
-	var oldval float64
-	oldTime, err := ms.storer.Get(name, &oldval)
+	newValue, err := castToFloat(absolute)
+	if err != nil {
+		err = ErrNonNumeric
+		return
+	}
+
+	// Fetch last value & time
+	var oldValue float64
+	oldTime, err := ms.storer.Get(name, &oldValue)
+	if err != nil && err != persist.ErrNotFound {
+		return
+	}
+
+	// Store new value & time (no IO flush until Save)
+	newTime := ms.storer.Set(name, newValue)
+
+	// First value
 	if err == persist.ErrNotFound {
-		oldval = 0
-	} else if err != nil {
-		return sampledValue, errors.Wrapf(err, "sample-key: %s", name)
-	}
-	// And replace it with the new value which we want to keep
-	newTime := ms.storer.Set(name, floatValue)
-
-	if err == nil {
-		duration := newTime - oldTime
-		if duration == 0 {
-			return sampledValue, fmt.Errorf("samples for %s are too close in time, skipping sampling", name)
-		}
-
-		if floatValue-oldval < 0 {
-			return sampledValue, fmt.Errorf("source for %s was reseted, skipping sampling", name)
-		}
-		if sourceType == DELTA {
-			sampledValue = floatValue - oldval
-		} else {
-			sampledValue = (floatValue - oldval) / float64(duration)
-		}
+		return 0, nil
 	}
 
-	return sampledValue, nil
+	// Time constraints
+	duration := newTime - oldTime
+	if duration == 0 {
+		err = ErrTooCloseSamples
+		return
+	}
+
+	elapsed = newValue - oldValue
+	if elapsed < 0 {
+		err = ErrSameOldValue
+		return
+	}
+
+	if sourceType == RATE {
+		elapsed = elapsed / float64(duration)
+	}
+
+	return
 }
 
 // MarshalJSON adapts the internal structure of the metrics Set to the payload that is compliant with the protocol

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -14,6 +14,12 @@ import (
 // each one.
 type SourceType int
 
+// group identifies a metric group
+type group struct {
+	field string
+	value string
+}
+
 const (
 	// GAUGE is a value that may increase and decrease. It is stored as-is.
 	GAUGE SourceType = iota
@@ -35,17 +41,25 @@ var (
 
 // Set is the basic structure for storing metrics.
 type Set struct {
-	storer       persist.Storer
-	Metrics      map[string]interface{}
-	uniqueFields []string
+	storer  persist.Storer
+	Metrics map[string]interface{}
+	group   group
 }
 
 // NewSet creates new metrics set.
-func NewSet(eventType string, storer persist.Storer, uniqueFields ...string) (*Set, error) {
+func NewSet(eventType string, storer persist.Storer) (*Set, error) {
+	return NewSetGroup(eventType, storer, "", "")
+}
+
+// NewSetGroup creates a metrics set that will attach all the metrics to the given field-value.
+func NewSetGroup(eventType string, storer persist.Storer, field, value string) (*Set, error) {
 	ms := Set{
-		Metrics:      map[string]interface{}{},
-		storer:       storer,
-		uniqueFields: uniqueFields,
+		Metrics: make(map[string]interface{}),
+		storer:  storer,
+		group: group{
+			field: field,
+			value: value,
+		},
 	}
 
 	err := ms.SetMetric("event_type", eventType, ATTRIBUTE)

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -24,9 +24,9 @@ type Attribute struct {
 const (
 	// GAUGE is a value that may increase and decrease. It is stored as-is.
 	GAUGE SourceType = iota
-	// RATE is an ever-growing value which might be reseted. The package calculates the change rate.
+	// RATE is an ever-growing value which might be reset. The package calculates the change rate.
 	RATE SourceType = iota
-	// DELTA is an ever-growing value which might be reseted. The package calculates the difference between samples.
+	// DELTA is an ever-growing value which might be reset. The package calculates the difference between samples.
 	DELTA SourceType = iota
 	// ATTRIBUTE is any string value
 	ATTRIBUTE SourceType = iota
@@ -54,13 +54,13 @@ type Set struct {
 	nsAttributes []Attribute
 }
 
-// NewSet creates new metrics set, optionally related to a list of attributes.
-// If related attributes are used, then a new attribute-metric is added per kv-pair.
-func NewSet(eventType string, storer persist.Storer, nsAttributes ...Attribute) (s *Set, err error) {
+// NewSet creates new metrics set, optionally related to a list of attributes. These attributes makes the metric-set unique.
+// If related attributes are used, then new attributes are added.
+func NewSet(eventType string, storer persist.Storer, attributes ...Attribute) (s *Set, err error) {
 	s = &Set{
 		Metrics:      make(map[string]interface{}),
 		storer:       storer,
-		nsAttributes: nsAttributes,
+		nsAttributes: attributes,
 	}
 
 	err = s.SetMetric("event_type", eventType, ATTRIBUTE)
@@ -68,7 +68,7 @@ func NewSet(eventType string, storer persist.Storer, nsAttributes ...Attribute) 
 		return
 	}
 
-	for _, attr := range nsAttributes {
+	for _, attr := range attributes {
 		err = s.SetMetric(attr.Key, attr.Value, ATTRIBUTE)
 		if err != nil {
 			return

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -45,6 +45,8 @@ var (
 	ErrNoStoreToCalcDiff = errors.New("cannot use deltas nor rates without persistent store")
 	ErrTooCloseSamples   = errors.New("samples too close in time, skipping")
 	ErrNegativeDiff      = errors.New("source was reset, skipping")
+	ErrOverrideSetAttrs  = errors.New("cannot overwrite metric-set attributes")
+	ErrDeltaWithNoAttrs  = errors.New("delta/rate metrics should be attached to an attribute identified metric-set")
 )
 
 // Set is the basic structure for storing metrics.
@@ -56,6 +58,7 @@ type Set struct {
 
 // NewSet creates new metrics set, optionally related to a list of attributes. These attributes makes the metric-set unique.
 // If related attributes are used, then new attributes are added.
+// TODO remove obsolete returned error
 func NewSet(eventType string, storer persist.Storer, attributes ...Attribute) (s *Set, err error) {
 	s = &Set{
 		Metrics:      make(map[string]interface{}),
@@ -63,16 +66,10 @@ func NewSet(eventType string, storer persist.Storer, attributes ...Attribute) (s
 		nsAttributes: attributes,
 	}
 
-	err = s.SetMetric("event_type", eventType, ATTRIBUTE)
-	if err != nil {
-		return
-	}
+	s.setSetAttribute("event_type", eventType)
 
 	for _, attr := range attributes {
-		err = s.SetMetric(attr.Key, attr.Value, ATTRIBUTE)
-		if err != nil {
-			return
-		}
+		s.setSetAttribute(attr.Key, attr.Value)
 	}
 
 	return
@@ -88,16 +85,21 @@ func Attr(key string, value string) Attribute {
 
 // SetMetric adds a metric to the Set object or updates the metric value if the metric already exists.
 // It calculates elapsed difference for RATE and DELTA types.
-func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) error {
-	var err error
+// WarnDeltaWithNoAttrs error is returned as a warning if a RATE or DELTA is used and the metric-set does not contain
+// any Attribute.
+func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) (err error) {
+	var errElapsed error
 	var newValue = value
 
 	// Only sample metrics of numeric type
 	switch sourceType {
 	case RATE, DELTA:
-		newValue, err = ms.elapsedDifference(name, value, sourceType)
-		if err != nil {
-			return errors.Wrapf(err, "cannot calculate elapsed difference for metric: %s value %v", name, value)
+		if len(ms.nsAttributes) == 0 {
+			err = ErrDeltaWithNoAttrs
+		}
+		newValue, errElapsed = ms.elapsedDifference(name, value, sourceType)
+		if errElapsed != nil {
+			return errors.Wrapf(errElapsed, "cannot calculate elapsed difference for metric: %s value %v", name, value)
 		}
 	case GAUGE:
 		newValue, err = castToFloat(value)
@@ -105,15 +107,26 @@ func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) 
 			return fmt.Errorf("non-numeric value for gauge metric: %s value: %v", name, value)
 		}
 	case ATTRIBUTE:
-		if _, ok := value.(string); !ok {
+		strVal, ok := value.(string)
+		if !ok {
 			return fmt.Errorf("non-string source type for attribute %s", name)
+		}
+		for _, attr := range ms.nsAttributes {
+			if name == attr.Key && strVal == attr.Value {
+				return ErrOverrideSetAttrs
+			}
 		}
 	default:
 		return fmt.Errorf("unknown source type for key %s", name)
 	}
 
 	ms.Metrics[name] = newValue
-	return nil
+
+	return
+}
+
+func (ms *Set) setSetAttribute(name string, value string) {
+	ms.Metrics[name] = value
 }
 
 func castToFloat(value interface{}) (float64, error) {

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -85,7 +85,7 @@ func Attr(key string, value string) Attribute {
 
 // SetMetric adds a metric to the Set object or updates the metric value if the metric already exists.
 // It calculates elapsed difference for RATE and DELTA types.
-// WarnDeltaWithNoAttrs error is returned as a warning if a RATE or DELTA is used and the metric-set does not contain
+// ErrDeltaWithNoAttrs error is returned as a warning if a RATE or DELTA is used and the metric-set does not contain
 // any Attribute.
 func (ms *Set) SetMetric(name string, value interface{}, sourceType SourceType) (err error) {
 	var errElapsed error

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -70,7 +70,7 @@ func TestSet_SetMetricCachesRateAndDeltas(t *testing.T) {
 	for _, sourceType := range []SourceType{DELTA, RATE} {
 		persist.SetNow(fd.Now)
 
-		ms, err := NewSet("some-event-type", storer)
+		ms, err := NewSet("some-event-type", storer, Attr("k", "v"))
 		assert.NoError(t, err)
 
 		for _, tt := range rateAndDeltaTests {
@@ -84,7 +84,7 @@ func TestSet_SetMetricCachesRateAndDeltas(t *testing.T) {
 			}
 
 			var v interface{}
-			_, err := storer.Get(key, &v)
+			_, err := storer.Get(ms.namespace(key), &v)
 			if err == persist.ErrNotFound {
 				t.Errorf("key %s not in cache for case %s", tt.key, tt.testCase)
 			} else if tt.cache != v {
@@ -127,7 +127,7 @@ func TestSet_SetMetric_IncorrectMetricType(t *testing.T) {
 }
 
 func TestSet_MarshalJSON(t *testing.T) {
-	ms, err := NewSet("some-event-type", persist.NewInMemoryStore())
+	ms, err := NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v"))
 	assert.NoError(t, err)
 
 	ms.SetMetric("foo", 1, RATE)
@@ -139,7 +139,7 @@ func TestSet_MarshalJSON(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"bar":0,"baz":1,"event_type":"some-event-type","foo":0,"quux":"bar"}`,
+		`{"bar":0,"baz":1,"event_type":"some-event-type","foo":0,"k":"v","quux":"bar"}`,
 		string(marshaled),
 	)
 }

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -171,7 +171,7 @@ func TestNewSet_FileStore_StoresBetweenRuns(t *testing.T) {
 	assert.Equal(t, 2.0, set2.Metrics["foo"])
 }
 
-func TestNewSetGroup_SolvesCacheCollision(t *testing.T) {
+func TestNewSetWithKV_SolvesCacheCollision(t *testing.T) {
 	fd := FakeData{}
 	persist.SetNow(fd.Now)
 
@@ -181,11 +181,11 @@ func TestNewSetGroup_SolvesCacheCollision(t *testing.T) {
 	storeWrite, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	ms1, err := NewSetGroup("type", storeWrite, "pod", "pod-a")
+	ms1, err := NewSet("type", storeWrite, NewKV("pod", "pod-a"))
 	assert.NoError(t, err)
-	ms2, err := NewSetGroup("type", storeWrite, "pod", "pod-a")
+	ms2, err := NewSet("type", storeWrite, NewKV("pod", "pod-a"))
 	assert.NoError(t, err)
-	ms3, err := NewSetGroup("type", storeWrite, "pod", "pod-b")
+	ms3, err := NewSet("type", storeWrite, NewKV("pod", "pod-b"))
 	assert.NoError(t, err)
 
 	assert.NoError(t, ms1.SetMetric("field", 1, DELTA))
@@ -198,7 +198,7 @@ func TestNewSetGroup_SolvesCacheCollision(t *testing.T) {
 	storeRead, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	msRead, err := NewSetGroup("type", storeRead, "pod", "pod-a")
+	msRead, err := NewSet("type", storeRead, NewKV("pod", "pod-a"))
 	assert.NoError(t, err)
 
 	// write is required to make data available for read

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -226,7 +226,7 @@ func TestNewSetRelatedTo_SolvesCacheCollision(t *testing.T) {
 	// write is required to make data available for read
 	assert.NoError(t, msRead.SetMetric("field", 10, DELTA))
 
-	assert.Equal(t, 8.0, msRead.Metrics["field"], "read metrics: %+v", msRead.Metrics)
+	assert.Equal(t, 8.0, msRead.Metrics["field"], "read metric-set: %+v", msRead.Metrics)
 }
 
 func tempFile() string {

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -171,7 +171,7 @@ func TestNewSet_FileStore_StoresBetweenRuns(t *testing.T) {
 	assert.Equal(t, 2.0, set2.Metrics["foo"])
 }
 
-func TestNewSetRelatedTo_AddsAttributes(t *testing.T) {
+func TestNewSet_Attr_AddsAttributes(t *testing.T) {
 	fd := FakeData{}
 	persist.SetNow(fd.Now)
 
@@ -184,16 +184,16 @@ func TestNewSetRelatedTo_AddsAttributes(t *testing.T) {
 	set, err := NewSet(
 		"type",
 		storeWrite,
-		RelatedTo("pod", "pod-a"),
-		RelatedTo("node", "node-a"),
+		Attr("pod", "pod-a"),
+		Attr("node", "node-a"),
 	)
-	assert.NoError(t, err)
 
+	assert.NoError(t, err)
 	assert.Equal(t, "pod-a", set.Metrics["pod"])
 	assert.Equal(t, "node-a", set.Metrics["node"])
 }
 
-func TestNewSetRelatedTo_SolvesCacheCollision(t *testing.T) {
+func TestNewSet_Attr_SolvesCacheCollision(t *testing.T) {
 	fd := FakeData{}
 	persist.SetNow(fd.Now)
 
@@ -203,11 +203,11 @@ func TestNewSetRelatedTo_SolvesCacheCollision(t *testing.T) {
 	storeWrite, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	ms1, err := NewSet("type", storeWrite, RelatedTo("pod", "pod-a"))
+	ms1, err := NewSet("type", storeWrite, Attr("pod", "pod-a"))
 	assert.NoError(t, err)
-	ms2, err := NewSet("type", storeWrite, RelatedTo("pod", "pod-a"))
+	ms2, err := NewSet("type", storeWrite, Attr("pod", "pod-a"))
 	assert.NoError(t, err)
-	ms3, err := NewSet("type", storeWrite, RelatedTo("pod", "pod-b"))
+	ms3, err := NewSet("type", storeWrite, Attr("pod", "pod-b"))
 	assert.NoError(t, err)
 
 	assert.NoError(t, ms1.SetMetric("field", 1, DELTA))
@@ -220,7 +220,7 @@ func TestNewSetRelatedTo_SolvesCacheCollision(t *testing.T) {
 	storeRead, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	msRead, err := NewSet("type", storeRead, RelatedTo("pod", "pod-a"))
+	msRead, err := NewSet("type", storeRead, Attr("pod", "pod-a"))
 	assert.NoError(t, err)
 
 	// write is required to make data available for read
@@ -230,7 +230,7 @@ func TestNewSetRelatedTo_SolvesCacheCollision(t *testing.T) {
 }
 
 func TestSet_namespace(t *testing.T) {
-	s, err := NewSet("type", persist.NewInMemoryStore(), RelatedTo("k", "v"))
+	s, err := NewSet("type", persist.NewInMemoryStore(), Attr("k", "v"))
 	assert.NoError(t, err)
 
 	assert.Equal(t, fmt.Sprintf("k==v::foo"), s.namespace("foo"))
@@ -239,8 +239,8 @@ func TestSet_namespace(t *testing.T) {
 	s, err = NewSet(
 		"type",
 		persist.NewInMemoryStore(),
-		RelatedTo("k1", "v1"),
-		RelatedTo("k2", "v2"),
+		Attr("k1", "v1"),
+		Attr("k2", "v2"),
 	)
 	assert.NoError(t, err)
 
@@ -250,8 +250,8 @@ func TestSet_namespace(t *testing.T) {
 	s, err = NewSet(
 		"type",
 		persist.NewInMemoryStore(),
-		RelatedTo("k2", "v2"),
-		RelatedTo("k1", "v1"),
+		Attr("k2", "v2"),
+		Attr("k1", "v1"),
 	)
 	assert.NoError(t, err)
 

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -229,6 +229,35 @@ func TestNewSetRelatedTo_SolvesCacheCollision(t *testing.T) {
 	assert.Equal(t, 8.0, msRead.Metrics["field"], "read metric-set: %+v", msRead.Metrics)
 }
 
+func TestSet_namespace(t *testing.T) {
+	s, err := NewSet("type", persist.NewInMemoryStore(), RelatedTo("k", "v"))
+	assert.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("k==v::foo"), s.namespace("foo"))
+
+	// several attributed are supported
+	s, err = NewSet(
+		"type",
+		persist.NewInMemoryStore(),
+		RelatedTo("k1", "v1"),
+		RelatedTo("k2", "v2"),
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("k1==v1::k2==v2::foo"), s.namespace("foo"))
+
+	// provided attributes order does not matter
+	s, err = NewSet(
+		"type",
+		persist.NewInMemoryStore(),
+		RelatedTo("k2", "v2"),
+		RelatedTo("k1", "v1"),
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("k1==v1::k2==v2::foo"), s.namespace("foo"))
+}
+
 func tempFile() string {
 	dir, err := ioutil.TempDir("", "file_store")
 	if err != nil {

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -153,7 +153,7 @@ func TestNewSet_FileStore_StoresBetweenRuns(t *testing.T) {
 	s, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	set1, err := NewSet("type", s)
+	set1, err := NewSet("type", s, Attr("k", "v"))
 	assert.NoError(t, err)
 
 	assert.NoError(t, set1.SetMetric("foo", 1, DELTA))
@@ -163,7 +163,7 @@ func TestNewSet_FileStore_StoresBetweenRuns(t *testing.T) {
 	s2, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	set2, err := NewSet("type", s2)
+	set2, err := NewSet("type", s2, Attr("k", "v"))
 	assert.NoError(t, err)
 
 	assert.NoError(t, set2.SetMetric("foo", 3, DELTA))

--- a/docs/toolset/README.md
+++ b/docs/toolset/README.md
@@ -18,4 +18,4 @@ of the core SDK, implement common operations that may be reused in different int
 ### Other helper libraries
 
 * [HTTP](http.md)
-* [JMX](jmx.go)
+* [JMX](jmx.md)

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -79,8 +79,8 @@ func (e *Entity) isLocalEntity() bool {
 }
 
 // NewMetricSet returns a new instance of Set with its sample attached to the integration.
-func (e *Entity) NewMetricSet(eventType string) (s *metric.Set, err error) {
-	s, err = metric.NewSet(eventType, e.storer)
+func (e *Entity) NewMetricSet(eventType string, nameSpacingAttributes ...metric.Attribute) (s *metric.Set, err error) {
+	s, err = metric.NewSet(eventType, e.storer, nameSpacingAttributes...)
 	if err != nil {
 		return
 	}

--- a/persist/storer.go
+++ b/persist/storer.go
@@ -191,7 +191,7 @@ func (j inMemoryStore) Get(key string, valuePtr interface{}) (int64, error) {
 	return entry.Timestamp, nil
 }
 
-// flushcache marshalls all the cached data into JSON, ready to be stored into disk
+// flushCache marshalls all the cached data into JSON, ready to be stored into disk
 func (j *inMemoryStore) flushCache() error {
 	for k, v := range j.cachedData {
 		bytes, err := json.Marshal(v)

--- a/persist/storer.go
+++ b/persist/storer.go
@@ -50,6 +50,7 @@ type Storer interface {
 type inMemoryStore struct {
 	cachedData map[string]jsonEntry
 	Data       map[string][]byte
+	Timestamps map[string]int64
 }
 
 // Holder for any entry in the JSON storage
@@ -92,6 +93,7 @@ func NewInMemoryStore() Storer {
 	return &inMemoryStore{
 		cachedData: make(map[string]jsonEntry),
 		Data:       make(map[string][]byte),
+		Timestamps: make(map[string]int64),
 	}
 }
 
@@ -221,5 +223,6 @@ func (j *fileStore) loadFromDisk() error {
 func (j inMemoryStore) Delete(key string) error {
 	delete(j.cachedData, key)
 	delete(j.Data, key)
+	delete(j.Timestamps, key)
 	return nil
 }

--- a/persist/storer.go
+++ b/persist/storer.go
@@ -50,7 +50,6 @@ type Storer interface {
 type inMemoryStore struct {
 	cachedData map[string]jsonEntry
 	Data       map[string][]byte
-	Timestamps map[string]int64
 }
 
 // Holder for any entry in the JSON storage
@@ -93,7 +92,6 @@ func NewInMemoryStore() Storer {
 	return &inMemoryStore{
 		cachedData: make(map[string]jsonEntry),
 		Data:       make(map[string][]byte),
-		Timestamps: make(map[string]int64),
 	}
 }
 
@@ -223,6 +221,5 @@ func (j *fileStore) loadFromDisk() error {
 func (j inMemoryStore) Delete(key string) error {
 	delete(j.cachedData, key)
 	delete(j.Data, key)
-	delete(j.Timestamps, key)
 	return nil
 }

--- a/persist/storer_test.go
+++ b/persist/storer_test.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 	"reflect"
@@ -418,4 +419,19 @@ func TestFileStorer_Save(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, testStruct{555, 444}, structValue)
 
+}
+
+func TestInMemoryStore_flushCache(t *testing.T) {
+	nowTime := time.Now()
+	setNow(func() time.Time {
+		return nowTime
+	})
+
+	s := NewInMemoryStore().(*inMemoryStore)
+
+	_ = s.Set("k", "v")
+
+	assert.NoError(t, s.flushCache())
+
+	assert.Equal(t, fmt.Sprintf("{\"Timestamp\":%d,\"Value\":\"v\"}", nowTime.Unix()), string(s.Data["k"]))
 }

--- a/persist/storer_test.go
+++ b/persist/storer_test.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -33,24 +34,24 @@ func (m *memoryStorerProvider) prepareToRead(s Storer) (Storer, error) {
 }
 
 type diskStorerProvider struct {
-	rootDir string
+	filePath string
 }
 
 func (j *diskStorerProvider) new() (Storer, error) {
-	if j.rootDir == "" {
-		var err error
-		j.rootDir, err = ioutil.TempDir("", "disk_storage")
-		if err != nil {
-			return nil, err
-		}
+	if j.filePath == "" {
+		j.filePath = filePath()
 	}
 
-	ds, err := NewFileStore(path.Join(j.rootDir, "storage.json"), log.NewStdErr(true), DefaultTTL)
+	return NewFileStore(j.filePath, log.NewStdErr(true), DefaultTTL)
+}
+
+func filePath() string {
+	rootDir, err := ioutil.TempDir("", "disk_storage")
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
-	return ds, nil
+	return path.Join(rootDir, "storage.json")
 }
 
 func (j *diskStorerProvider) prepareToRead(s Storer) (Storer, error) {
@@ -434,4 +435,62 @@ func TestInMemoryStore_flushCache(t *testing.T) {
 	assert.NoError(t, s.flushCache())
 
 	assert.Equal(t, fmt.Sprintf("{\"Timestamp\":%d,\"Value\":\"v\"}", nowTime.Unix()), string(s.Data["k"]))
+}
+
+// Exaplained through different deserialization approaches
+func TestFileStore_Save(t *testing.T) {
+	nowTime := time.Now()
+	setNow(func() time.Time {
+		return nowTime
+	})
+
+	expectedTS := nowTime.Unix()
+
+	storeProvider := diskStorerProvider{}
+	s, err := storeProvider.new()
+	assert.NoError(t, err)
+
+	_ = s.Set("k", "v")
+
+	// assertion 1: using diskStorerProvider
+	s, err = storeProvider.prepareToRead(s)
+	assert.NoError(t, err)
+
+	var val string
+	ts, err := s.Get("k", &val)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "v", val)
+	assert.Equal(t, expectedTS, ts)
+
+	// reading file contents
+	readStore, err := ioutil.ReadFile(storeProvider.filePath)
+	assert.NoError(t, err)
+
+	// assertion 2.1: using a store with value deserialization on demand by Get
+	unserializedStore := NewInMemoryStore()
+	json.Unmarshal(readStore, &unserializedStore)
+
+	var v string
+	ts, err = unserializedStore.Get("k", &v)
+	assert.NoError(t, err)
+	assert.Equal(t, "v", v)
+	assert.Equal(t, expectedTS, ts)
+
+	// assertion 2.2: manual deserialization
+	expectedContent := fmt.Sprintf("{\"Data\":{ \"k\": { \"Timestamp\":%d, \"Value\":\"v\" } } }", nowTime.Unix())
+	var readJSON map[string]map[string][]byte
+	json.Unmarshal(readStore, &readJSON)
+	var expectedJSON map[string]map[string][]byte
+	json.Unmarshal([]byte(expectedContent), &expectedJSON)
+
+	bytes, ok := readJSON["Data"]["k"]
+	assert.True(t, ok)
+	var entry jsonEntry
+	err = json.Unmarshal(bytes, &entry)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "v", entry.Value)
+	assert.Equal(t, expectedTS, entry.Timestamp)
+
 }


### PR DESCRIPTION
#### Description of the changes

Fixes cache collision on the store for _rate&deltas_ when a **same metric name** is used.

Attributes are supported to namespace the metric name on the _NewSet_ constructor.

Fix test at `TestNewSet_Attr_SolvesCacheCollision` https://github.com/newrelic/infra-integrations-sdk/pull/106/files#diff-d41479d78f43948797a5970be862f5e0R196

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
