### PR TITLE
Fixed nil pointer when creating an entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New packages `inventory`, `event` with proper constructors 
 - Integration parametrized creation via optional `Option`s
 
+### Fixed
+- Nil pointer when creating a Remote entity after creating a Local entity.
+
 ### Changed
 - Package `sdk` renamed to `integration`
 - Package `cache` renamed to `persist` 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -111,7 +111,7 @@ func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
 
 	// we should change this to map for performance
 	for _, e = range i.Entities {
-		if e.Metadata.Name == name && e.Metadata.Namespace == namespace {
+		if e.Metadata != nil && e.Metadata.Name == name && e.Metadata.Namespace == namespace {
 			return e, nil
 		}
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -252,6 +252,18 @@ func newTestIntegration(t *testing.T) *Integration {
 	return i
 }
 
+func TestIntegration_CreateLocalAndRemoteEntities(t *testing.T) {
+	i, err := New(integrationName, integrationVersion)
+	assert.NoError(t, err)
+
+	local := i.LocalEntity()
+	assert.NotEqual(t, local, nil)
+
+	remote, err := i.Entity("Entity1", "test")
+	assert.NoError(t, err)
+	assert.NotEqual(t, remote, nil)
+}
+
 type testWriter struct {
 	testFunc func([]byte)
 }


### PR DESCRIPTION
Inside Entity creation there is a loop that checks previous entities' Metadata (Name and Namespace). The problem is that local entities don't have an associate Metadata, so if you create a local entity and then a remote entity a nil pointer crash happens.