### PR TITLE
Fix debug mode for default logger

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -51,7 +51,6 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 		Entities:           []*Entity{},
 		writer:             os.Stdout,
 		locker:             DisabledLocker,
-		logger:             log.NewStdErr(false),
 	}
 
 	for _, opt := range opts {
@@ -71,12 +70,17 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 	defaultArgs := args.GetDefaultArgs(i.args)
 	i.prettyOutput = defaultArgs.Pretty
 
+	// Setting default values, if not set yet
 	if i.storer == nil {
 		var err error
 		i.storer, err = persist.NewFileStore(persist.DefaultPath(i.Name), i.logger, persist.DefaultTTL)
 		if err != nil {
 			return nil, fmt.Errorf("can't create store: %s", err)
 		}
+	}
+
+	if i.logger == nil {
+		i.logger = log.NewStdErr(defaultArgs.Verbose)
 	}
 
 	return


### PR DESCRIPTION
#### Description of the changes

Logger now is responsive to the `--verbose` configuration argument.

The patch include unit tests.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
