### PR TITLE
    Restore and deprecate global logger

### DIFF
--- a/docs/toolset/log.md
+++ b/docs/toolset/log.md
@@ -7,6 +7,7 @@ any logger implementation that fulfills the interface:
 type Logger interface {
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 }
 ```
@@ -35,6 +36,10 @@ func (s verySimpleLogger) Infof(format string, args ...interface{}) {
 	fmt.Println("INFO:", fmt.Sprintf(format, args...))
 }
 
+func (s verySimpleLogger) Warnf(format string, args ...interface{}) {
+	fmt.Println("WARN:", fmt.Sprintf(format, args...))
+}
+
 func (s verySimpleLogger) Errorf(format string, args ...interface{}) {
 	fmt.Println("ERROR:", fmt.Sprintf(format, args...))
 }
@@ -47,5 +52,6 @@ type nullLogger struct{}
 
 func (nullLogger) Debugf(format string, args ...interface{}) { }
 func (nullLogger) Infof(format string, args ...interface{}) { }
+func (nullLogger) Warnf(format string, args ...interface{}) { }
 func (nullLogger) Errorf(format string, args ...interface{}) { }
 ```

--- a/docs/v2tov3.md
+++ b/docs/v2tov3.md
@@ -133,7 +133,7 @@ For a complete view of the GoSDK `v3`, please refer to [TODO: link API and tutor
 
 ### Logging
 
-* The global logger has been removed. Now the user can specify the logger implementation through the `log.Logger` interface.
+* The global logger has been deprecated. Now the user can specify the logger implementation through the `log.Logger` interface.
 
 ### Integration creation and publication
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -71,16 +71,16 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 	i.prettyOutput = defaultArgs.Pretty
 
 	// Setting default values, if not set yet
+	if i.logger == nil {
+		i.logger = log.NewStdErr(defaultArgs.Verbose)
+	}
+
 	if i.storer == nil {
 		var err error
 		i.storer, err = persist.NewFileStore(persist.DefaultPath(i.Name), i.logger, persist.DefaultTTL)
 		if err != nil {
 			return nil, fmt.Errorf("can't create store: %s", err)
 		}
-	}
-
-	if i.logger == nil {
-		i.logger = log.NewStdErr(defaultArgs.Verbose)
 	}
 
 	return

--- a/log/log.go
+++ b/log/log.go
@@ -11,13 +11,14 @@ import (
 // Logger defines a facade for a simple logger
 type Logger interface {
 	Debugf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 }
 
 var (
 	// Discard provides a discard all policy logger
-	Discard = New(false, ioutil.Discard)
+	Discard = NewWriter(false, ioutil.Discard)
 )
 
 type defaultLogger struct {
@@ -27,11 +28,11 @@ type defaultLogger struct {
 
 // NewStdErr creates a logger with stderr output, the argument enables Debug (verbose) output
 func NewStdErr(debug bool) Logger {
-	return New(debug, os.Stderr)
+	return NewWriter(debug, os.Stderr)
 }
 
-// New creates a logger using the provided writer. The 'debug' argument enables Debug (verbose) output
-func New(debug bool, w io.Writer) Logger {
+// NewWriter creates a logger using the provided writer. The 'debug' argument enables Debug (verbose) output
+func NewWriter(debug bool, w io.Writer) Logger {
 	return &defaultLogger{
 		logger: log.New(w, "", 0),
 		debug:  debug,
@@ -55,9 +56,79 @@ func (l *defaultLogger) Errorf(format string, args ...interface{}) {
 	l.prefixPrint("ERR", format, args...)
 }
 
+// Warnf logs a formatted message at level Warning.
+func (l *defaultLogger) Warnf(format string, args ...interface{}) {
+	l.prefixPrint("WARN", format, args...)
+}
+
 func (l *defaultLogger) prefixPrint(prefix string, format string, args ...interface{}) {
 	prev := log.Prefix()
 	log.SetPrefix(prefix)
 	l.logger.Printf(format, args...)
 	log.SetPrefix(prev)
+}
+
+// Deprecated methods, kept to do v2 to v3 migration less painful
+
+var globalLogger defaultLogger
+
+func init() {
+	SetupLogging(false)
+}
+
+// SetupLogging redirects global logs to stderr and configures the log level.
+// Deprecated. Use log.NewWriter, log.NewStdErr or any custom implementation of the log.Logger interface.
+func SetupLogging(verbose bool) {
+	globalLogger = defaultLogger{
+		logger: log.New(os.Stderr, "", 0),
+		debug:  verbose,
+	}
+}
+
+// New creates an already configured logger.
+// Deprecated. Use log.NewWriter, log.NewStdErr or any custom implementation of the log.Logger interface.
+func New(verbose bool) Logger {
+	return NewStdErr(verbose)
+}
+
+// ConfigureLogger configures an already created logger. Redirects logs to stderr and configures the log level.
+// Deprecated. Use log.NewWriter, log.NewStdErr or any custom implementation of the log.Logger interface.
+func ConfigureLogger(logger Logger, verbose bool) {
+	if logImpl, ok := logger.(*defaultLogger); ok {
+		*logImpl = *New(verbose).(*defaultLogger)
+
+		//logImpl.logger = log.New(os.Stderr, "", 0)
+		//logImpl.debug = verbose
+	}
+}
+
+// Debug logs a formatted message at level Debug.
+// Deprecated. Use Debugf function of the log.Logger interface.
+func Debug(format string, args ...interface{}) {
+	globalLogger.Debugf(format, args...)
+}
+
+// Info logs a formatted message at level Info.
+// Deprecated. Use Infof function of the log.Logger interface.
+func Info(format string, args ...interface{}) {
+	globalLogger.Infof(format, args...)
+}
+
+// Warn logs a formatted message at level Warn.
+// Deprecated. Use the log.Logger interface.
+func Warn(format string, args ...interface{}) {
+	globalLogger.Warnf(format, args...)
+}
+
+// Error logs a formatted message at level Error.
+// Deprecated. Use Errorf function of the log.Logger interface.
+func Error(format string, args ...interface{}) {
+	globalLogger.Errorf(format, args...)
+}
+
+// Fatal logs an error at level Fatal, and makes the program exit with an error code.
+// Deprecated. Use the log.Logger interface.
+func Fatal(err error) {
+	globalLogger.prefixPrint("FATAL", "can't continue: %v", err)
+	panic(err)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -18,7 +18,7 @@ type Logger interface {
 
 var (
 	// Discard provides a discard all policy logger
-	Discard = NewWriter(false, ioutil.Discard)
+	Discard = New(false, ioutil.Discard)
 )
 
 type defaultLogger struct {
@@ -28,11 +28,11 @@ type defaultLogger struct {
 
 // NewStdErr creates a logger with stderr output, the argument enables Debug (verbose) output
 func NewStdErr(debug bool) Logger {
-	return NewWriter(debug, os.Stderr)
+	return New(debug, os.Stderr)
 }
 
-// NewWriter creates a logger using the provided writer. The 'debug' argument enables Debug (verbose) output
-func NewWriter(debug bool, w io.Writer) Logger {
+// New creates a logger using the provided writer. The 'debug' argument enables Debug (verbose) output
+func New(debug bool, w io.Writer) Logger {
 	return &defaultLogger{
 		logger: log.New(w, "", 0),
 		debug:  debug,
@@ -82,23 +82,6 @@ func SetupLogging(verbose bool) {
 	globalLogger = defaultLogger{
 		logger: log.New(os.Stderr, "", 0),
 		debug:  verbose,
-	}
-}
-
-// New creates an already configured logger.
-// Deprecated. Use log.NewWriter, log.NewStdErr or any custom implementation of the log.Logger interface.
-func New(verbose bool) Logger {
-	return NewStdErr(verbose)
-}
-
-// ConfigureLogger configures an already created logger. Redirects logs to stderr and configures the log level.
-// Deprecated. Use log.NewWriter, log.NewStdErr or any custom implementation of the log.Logger interface.
-func ConfigureLogger(logger Logger, verbose bool) {
-	if logImpl, ok := logger.(*defaultLogger); ok {
-		logImpl.logger = log.New(os.Stderr, "", 0)
-		logImpl.debug = verbose
-	} else {
-		logger.Warnf("configureLogger has received a deprecated, unsupported logger implementation. Can't configure it")
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -95,10 +95,10 @@ func New(verbose bool) Logger {
 // Deprecated. Use log.NewWriter, log.NewStdErr or any custom implementation of the log.Logger interface.
 func ConfigureLogger(logger Logger, verbose bool) {
 	if logImpl, ok := logger.(*defaultLogger); ok {
-		*logImpl = *New(verbose).(*defaultLogger)
-
-		//logImpl.logger = log.New(os.Stderr, "", 0)
-		//logImpl.debug = verbose
+		logImpl.logger = log.New(os.Stderr, "", 0)
+		logImpl.debug = verbose
+	} else {
+		logger.Warnf("configureLogger has received a deprecated, unsupported logger implementation. Can't configure it")
 	}
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -120,4 +120,3 @@ func TestSetupLoggingNotVerbose(t *testing.T) {
 	assert.NotContains(t, stdErrBytes.String(), "hello everybody")
 	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
 }
-

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDefaultLogger_Errorf(t *testing.T) {
 	var writer bytes.Buffer
-	l := NewWriter(false, &writer)
+	l := New(false, &writer)
 
 	l.Errorf("foo")
 	l.Errorf("bar")
@@ -26,7 +26,7 @@ func TestDefaultLogger_Errorf(t *testing.T) {
 
 func TestDefaultLogger_Warnf(t *testing.T) {
 	var writer bytes.Buffer
-	l := NewWriter(false, &writer)
+	l := New(false, &writer)
 
 	l.Warnf("foo")
 	l.Warnf("bar")
@@ -40,7 +40,7 @@ func TestDefaultLogger_Warnf(t *testing.T) {
 
 func TestDefaultLogger_Infof(t *testing.T) {
 	var writer bytes.Buffer
-	l := NewWriter(false, &writer)
+	l := New(false, &writer)
 
 	l.Infof("foo")
 
@@ -52,7 +52,7 @@ func TestDefaultLogger_Infof(t *testing.T) {
 
 func TestDefaultLogger_Debugf_DoesNotLogWhenNotActive(t *testing.T) {
 	var writer bytes.Buffer
-	l := NewWriter(false, &writer)
+	l := New(false, &writer)
 
 	l.Debugf("foo")
 
@@ -64,7 +64,7 @@ func TestDefaultLogger_Debugf_DoesNotLogWhenNotActive(t *testing.T) {
 
 func TestDefaultLogger_Debugf_LogsWhenActive(t *testing.T) {
 	var writer bytes.Buffer
-	l := NewWriter(true, &writer)
+	l := New(true, &writer)
 
 	l.Debugf("foo")
 
@@ -121,96 +121,3 @@ func TestSetupLoggingNotVerbose(t *testing.T) {
 	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
 }
 
-func TestConfigureLoggerVerbose(t *testing.T) {
-	// Capturing standard error of global logger
-	r, w, err := os.Pipe()
-	assert.NoError(t, err)
-	back := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = back
-	}()
-	defer r.Close()
-
-	l := defaultLogger{}
-	ConfigureLogger(&l, true)
-
-	l.Debugf("hello everybody")
-	l.Errorf("goodbye friend")
-	assert.NoError(t, w.Close())
-
-	stdErrBytes := new(bytes.Buffer)
-	stdErrBytes.ReadFrom(r)
-	assert.Contains(t, stdErrBytes.String(), "hello everybody")
-	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
-}
-
-func TestConfigureLoggerNotVerbose(t *testing.T) {
-	// Capturing standard error of global logger
-	r, w, err := os.Pipe()
-	assert.NoError(t, err)
-	back := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = back
-	}()
-	defer r.Close()
-
-	l := defaultLogger{}
-	ConfigureLogger(&l, false)
-
-	l.Debugf("hello everybody")
-	l.Errorf("goodbye friend")
-	assert.NoError(t, w.Close())
-
-	stdErrBytes := new(bytes.Buffer)
-	stdErrBytes.ReadFrom(r)
-	assert.NotContains(t, stdErrBytes.String(), "hello everybody")
-	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
-}
-
-func TestNewVerbose(t *testing.T) {
-	// Capturing standard error of global logger
-	r, w, err := os.Pipe()
-	assert.NoError(t, err)
-	back := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = back
-	}()
-	defer r.Close()
-
-	l := New(true)
-
-	l.Debugf("hello everybody")
-	l.Errorf("goodbye friend")
-	assert.NoError(t, w.Close())
-
-	stdErrBytes := new(bytes.Buffer)
-	stdErrBytes.ReadFrom(r)
-	assert.Contains(t, stdErrBytes.String(), "hello everybody")
-	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
-}
-
-func TestNewNotVerbose(t *testing.T) {
-	// Capturing standard error of global logger
-	r, w, err := os.Pipe()
-	assert.NoError(t, err)
-	back := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = back
-	}()
-	defer r.Close()
-
-	l := New(false)
-
-	l.Debugf("hello everybody")
-	l.Errorf("goodbye friend")
-	assert.NoError(t, w.Close())
-
-	stdErrBytes := new(bytes.Buffer)
-	stdErrBytes.ReadFrom(r)
-	assert.NotContains(t, stdErrBytes.String(), "hello everybody")
-	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
-}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"os"
 	"testing"
 
 	"bytes"
@@ -11,7 +12,7 @@ import (
 
 func TestDefaultLogger_Errorf(t *testing.T) {
 	var writer bytes.Buffer
-	l := New(false, &writer)
+	l := NewWriter(false, &writer)
 
 	l.Errorf("foo")
 	l.Errorf("bar")
@@ -23,9 +24,23 @@ func TestDefaultLogger_Errorf(t *testing.T) {
 	assert.Equal(t, 2, strings.Count(logged, "\n"), "should add carriage return on each error")
 }
 
+func TestDefaultLogger_Warnf(t *testing.T) {
+	var writer bytes.Buffer
+	l := NewWriter(false, &writer)
+
+	l.Warnf("foo")
+	l.Warnf("bar")
+
+	logged := writer.String()
+
+	assert.True(t, strings.Contains(logged, "foo"))
+	assert.True(t, strings.Contains(logged, "bar"))
+	assert.Equal(t, 2, strings.Count(logged, "\n"), "should add carriage return on each error")
+}
+
 func TestDefaultLogger_Infof(t *testing.T) {
 	var writer bytes.Buffer
-	l := New(false, &writer)
+	l := NewWriter(false, &writer)
 
 	l.Infof("foo")
 
@@ -37,7 +52,7 @@ func TestDefaultLogger_Infof(t *testing.T) {
 
 func TestDefaultLogger_Debugf_DoesNotLogWhenNotActive(t *testing.T) {
 	var writer bytes.Buffer
-	l := New(false, &writer)
+	l := NewWriter(false, &writer)
 
 	l.Debugf("foo")
 
@@ -49,7 +64,7 @@ func TestDefaultLogger_Debugf_DoesNotLogWhenNotActive(t *testing.T) {
 
 func TestDefaultLogger_Debugf_LogsWhenActive(t *testing.T) {
 	var writer bytes.Buffer
-	l := New(true, &writer)
+	l := NewWriter(true, &writer)
 
 	l.Debugf("foo")
 
@@ -57,4 +72,148 @@ func TestDefaultLogger_Debugf_LogsWhenActive(t *testing.T) {
 
 	assert.True(t, strings.Contains(logged, "foo"))
 	assert.Equal(t, 1, strings.Count(logged, "\n"))
+}
+
+// Tests for deprecated, old global logger
+func TestSetupLoggingVerbose(t *testing.T) {
+	// Capturing standard error of global logger
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	back := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = back
+	}()
+	defer r.Close()
+
+	SetupLogging(true)
+
+	Debug("hello everybody")
+	Error("goodbye friend")
+	assert.NoError(t, w.Close())
+
+	stdErrBytes := new(bytes.Buffer)
+	stdErrBytes.ReadFrom(r)
+	assert.Contains(t, stdErrBytes.String(), "hello everybody")
+	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
+}
+
+func TestSetupLoggingNotVerbose(t *testing.T) {
+	// Capturing standard error of global logger
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	back := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = back
+	}()
+	defer r.Close()
+
+	SetupLogging(false)
+
+	Debug("hello everybody")
+	Error("goodbye friend")
+	assert.NoError(t, w.Close())
+
+	stdErrBytes := new(bytes.Buffer)
+	stdErrBytes.ReadFrom(r)
+	assert.NotContains(t, stdErrBytes.String(), "hello everybody")
+	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
+}
+
+func TestConfigureLoggerVerbose(t *testing.T) {
+	t.Skip("Being solved")
+	// Capturing standard error of global logger
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	back := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = back
+	}()
+	defer r.Close()
+
+	l := defaultLogger{}
+	ConfigureLogger(&l, true)
+
+	Debug("hello everybody")
+	Error("goodbye friend")
+	assert.NoError(t, w.Close())
+
+	stdErrBytes := new(bytes.Buffer)
+	stdErrBytes.ReadFrom(r)
+	assert.Contains(t, stdErrBytes.String(), "hello everybody")
+	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
+}
+
+func TestConfigureLoggerNotVerbose(t *testing.T) {
+	t.Skip("Being solved")
+
+	// Capturing standard error of global logger
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	back := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = back
+	}()
+	defer r.Close()
+
+	l := defaultLogger{}
+	ConfigureLogger(&l, false)
+
+	Debug("hello everybody")
+	Error("goodbye friend")
+	assert.NoError(t, w.Close())
+
+	stdErrBytes := new(bytes.Buffer)
+	stdErrBytes.ReadFrom(r)
+	assert.NotContains(t, stdErrBytes.String(), "hello everybody")
+	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
+}
+
+func TestNewVerbose(t *testing.T) {
+	// Capturing standard error of global logger
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	back := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = back
+	}()
+	defer r.Close()
+
+	l := New(true)
+
+	l.Debugf("hello everybody")
+	l.Errorf("goodbye friend")
+	assert.NoError(t, w.Close())
+
+	stdErrBytes := new(bytes.Buffer)
+	stdErrBytes.ReadFrom(r)
+	assert.Contains(t, stdErrBytes.String(), "hello everybody")
+	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
+}
+
+func TestNewNotVerbose(t *testing.T) {
+	// Capturing standard error of global logger
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	back := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = back
+	}()
+	defer r.Close()
+
+	l := New(false)
+
+	l.Debugf("hello everybody")
+	l.Errorf("goodbye friend")
+	assert.NoError(t, w.Close())
+
+	stdErrBytes := new(bytes.Buffer)
+	stdErrBytes.ReadFrom(r)
+	assert.NotContains(t, stdErrBytes.String(), "hello everybody")
+	assert.Contains(t, stdErrBytes.String(), "goodbye friend")
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -122,7 +122,6 @@ func TestSetupLoggingNotVerbose(t *testing.T) {
 }
 
 func TestConfigureLoggerVerbose(t *testing.T) {
-	t.Skip("Being solved")
 	// Capturing standard error of global logger
 	r, w, err := os.Pipe()
 	assert.NoError(t, err)
@@ -136,8 +135,8 @@ func TestConfigureLoggerVerbose(t *testing.T) {
 	l := defaultLogger{}
 	ConfigureLogger(&l, true)
 
-	Debug("hello everybody")
-	Error("goodbye friend")
+	l.Debugf("hello everybody")
+	l.Errorf("goodbye friend")
 	assert.NoError(t, w.Close())
 
 	stdErrBytes := new(bytes.Buffer)
@@ -147,8 +146,6 @@ func TestConfigureLoggerVerbose(t *testing.T) {
 }
 
 func TestConfigureLoggerNotVerbose(t *testing.T) {
-	t.Skip("Being solved")
-
 	// Capturing standard error of global logger
 	r, w, err := os.Pipe()
 	assert.NoError(t, err)
@@ -162,8 +159,8 @@ func TestConfigureLoggerNotVerbose(t *testing.T) {
 	l := defaultLogger{}
 	ConfigureLogger(&l, false)
 
-	Debug("hello everybody")
-	Error("goodbye friend")
+	l.Debugf("hello everybody")
+	l.Errorf("goodbye friend")
 	assert.NoError(t, w.Close())
 
 	stdErrBytes := new(bytes.Buffer)


### PR DESCRIPTION
#### Description of the changes

    It keeps the public API of the global logger, but changes its internal
    implementation to not depend on logrus.

    This patch also restores the warning messages.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
