### PR TITLE
Skip JMX timeout test

### DIFF
--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -119,6 +119,8 @@ func TestJmxTimeoutQuery(t *testing.T) {
 }
 
 func TestJmxNoTimeoutQuery(t *testing.T) {
+	t.Skip("unreliable CI test")
+
 	defer Close()
 
 	if err := openWait("", "", "", "", openAttempts); err != nil {
@@ -131,6 +133,8 @@ func TestJmxNoTimeoutQuery(t *testing.T) {
 }
 
 func TestJmxTimeoutBigQuery(t *testing.T) {
+	t.Skip("unreliable CI test")
+
 	defer Close()
 
 	if err := openWait("", "", "", "", openAttempts); err != nil {


### PR DESCRIPTION
#### Description of the changes

Skip JMX timeout test, because CI runtime is unreliable.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
