### PR TITLE
Arguments getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Boolean support for *Gauge* metrics via `setMetric`
 - Adds `json.Unmarsall` support to `metric.Set`
+- Getters (HasMetrics, HasEvents, HasInventory) to the `args` package 
+to avoid calling `All() || Metrics`
 
 ### Fixed
 - Fixes Integration.Publish test

--- a/args/args.go
+++ b/args/args.go
@@ -26,6 +26,21 @@ func (d *DefaultArgumentList) All() bool {
 	return !d.Inventory && !d.Metrics && !d.Events
 }
 
+// HasMetrics returns if metrics should be published
+func (d *DefaultArgumentList) HasMetrics() bool {
+	return d.Metrics || d.All()
+}
+
+// HasEvents returns if events should be published
+func (d *DefaultArgumentList) HasEvents() bool {
+	return d.Events || d.All()
+}
+
+// HasInventory returns if inventory should be published
+func (d *DefaultArgumentList) HasInventory() bool {
+	return d.Inventory || d.All()
+}
+
 // HTTPClientArgumentList are meant to be used as flags from a custom integrations. With this you could
 // send this arguments from the command line.
 type HTTPClientArgumentList struct {

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -234,16 +234,40 @@ func TestGetDefaultArgsWithoutDefaults(t *testing.T) {
 	assertEqualArgs(t, sdk_args.DefaultArgumentList{}, *sdk_args.GetDefaultArgs(&argumentListWithoutDefaults{}))
 }
 
-func TestDefaultArgumentList_All(t *testing.T) {
-	defaults := sdk_args.DefaultArgumentList{}
-	withMetrics := sdk_args.DefaultArgumentList{Metrics: true}
-	withInventory := sdk_args.DefaultArgumentList{Inventory: true}
-	withEvents := sdk_args.DefaultArgumentList{Events: true}
+// Vars to test getters
+var (
+	defaultArgs              = sdk_args.DefaultArgumentList{}
+	defaultArgsWithMetrics   = sdk_args.DefaultArgumentList{Metrics: true}
+	defaultArgsWithInventory = sdk_args.DefaultArgumentList{Inventory: true}
+	defaultArgsWithEvents    = sdk_args.DefaultArgumentList{Events: true}
+)
 
-	assert.True(t, defaults.All())
-	assert.False(t, withMetrics.All())
-	assert.False(t, withInventory.All())
-	assert.False(t, withEvents.All())
+func TestDefaultArgumentList_All(t *testing.T) {
+	assert.True(t, defaultArgs.All())
+	assert.False(t, defaultArgsWithMetrics.All())
+	assert.False(t, defaultArgsWithInventory.All())
+	assert.False(t, defaultArgsWithEvents.All())
+}
+
+func TestDefaultArgumentList_HasMetrics(t *testing.T) {
+	assert.True(t, defaultArgs.HasMetrics())
+	assert.True(t, defaultArgsWithMetrics.HasMetrics())
+	assert.False(t, defaultArgsWithInventory.HasMetrics())
+	assert.False(t, defaultArgsWithEvents.HasMetrics())
+}
+
+func TestDefaultArgumentList_HasEvents(t *testing.T) {
+	assert.True(t, defaultArgs.HasEvents())
+	assert.False(t, defaultArgsWithMetrics.HasEvents())
+	assert.False(t, defaultArgsWithInventory.HasEvents())
+	assert.True(t, defaultArgsWithEvents.HasEvents())
+}
+
+func TestDefaultArgumentList_HasInventory(t *testing.T) {
+	assert.True(t, defaultArgs.HasInventory())
+	assert.False(t, defaultArgsWithMetrics.HasInventory())
+	assert.True(t, defaultArgsWithInventory.HasInventory())
+	assert.False(t, defaultArgsWithEvents.HasInventory())
 }
 
 func assertEqualArgs(t *testing.T, expected interface{}, args interface{}) {

--- a/docs/tutorial-code/single-entity/redis.go
+++ b/docs/tutorial-code/single-entity/redis.go
@@ -52,7 +52,7 @@ func main() {
 	// Create Integration
 	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	panicOnErr(err)
-	
+
 	entity := i.LocalEntity()
 	panicOnErr(err)
 


### PR DESCRIPTION
#### Description of the changes

Arguments getters.

To avoid people concatenating `All` conditionals like:

```golang
if args.GlobalArgs.All() || args.GlobalArgs.Inventory {
```

Adds support for:

```golang
if args.GlobalArgs.HasInventory() {
```

On the 3 metric types `HasInventory`, `HasEvents`, `HasMetrics`

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
