### PR TITLE
Entities require name and type

### DIFF
--- a/integration/entity.go
+++ b/integration/entity.go
@@ -43,7 +43,7 @@ func newLocalEntity(storer persist.Storer) *Entity {
 // newEntity creates a new remote-entity.
 func newEntity(name, namespace string, storer persist.Storer) (*Entity, error) {
 	// If one of the attributes is defined, both Name and Namespace are needed.
-	if name == "" && namespace != "" || name != "" && namespace == "" {
+	if name == "" || namespace == "" {
 		return nil, errors.New("entity name and type are required when defining one")
 	}
 

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -21,6 +21,12 @@ func TestNewEntity(t *testing.T) {
 	assert.Equal(t, "type", e.Metadata.Namespace)
 }
 
+func TestEntitiesRequireNameAndType(t *testing.T) {
+	_, err := newEntity("", "", nil)
+
+	assert.Error(t, err)
+}
+
 func TestAddNotificationEvent(t *testing.T) {
 	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
 	if err != nil {


### PR DESCRIPTION
#### Description of the changes

Entities require name and type, if empty an error should be returned. Otherwise we'll be using a local-entity under the hood.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
