### PR TITLE
Update integration.Publish method to print breaklines

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -154,7 +154,7 @@ func (i *Integration) Publish() error {
 	if err != nil {
 		return err
 	}
-
+	output = append(output, []byte{'\n'}...)
 	_, err = i.writer.Write(output)
 	defer i.Clear()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -61,7 +61,7 @@ func TestDefaultIntegrationWritesToStdout(t *testing.T) {
 	f.Close()
 	payload, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"4.0","data":[]}`, string(payload))
+	assert.Equal(t, "{\"name\":\"integration\",\"protocol_version\":\"2\",\"integration_version\":\"4.0\",\"data\":[]}\n", string(payload))
 }
 
 func TestIntegration_DefaultEntity(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -61,7 +61,7 @@ func TestDefaultIntegrationWritesToStdout(t *testing.T) {
 	f.Close()
 	payload, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"4.0","data":[]}` + "\n", string(payload))
+	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"4.0","data":[]}`+"\n", string(payload))
 }
 
 func TestIntegration_DefaultEntity(t *testing.T) {

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -25,7 +25,7 @@ func TestWriter(t *testing.T) {
 
 	assert.NoError(t, i.Publish())
 
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"7.0","data":[]}` + "\n", w.String())
+	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"7.0","data":[]}`+"\n", w.String())
 }
 
 func TestArgs(t *testing.T) {

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -25,7 +25,7 @@ func TestWriter(t *testing.T) {
 
 	assert.NoError(t, i.Publish())
 
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"7.0","data":[]}`, w.String())
+	assert.Equal(t, "{\"name\":\"integration\",\"protocol_version\":\"2\",\"integration_version\":\"7.0\",\"data\":[]}\n", w.String())
 }
 
 func TestArgs(t *testing.T) {


### PR DESCRIPTION
#### Description of the changes

The contract between the agent and integrations is that integrations
would print a single line output. If the execution of the integration
binary returns multiple integration outputs, they have to be separated
by a break line.

You can compare the current behavior with v2.2.0:

https://github.com/newrelic/infra-integrations-sdk/blob/v2.2.0/sdk/data.go#L95

As you can see, in that version we were using `Println()`

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
