### PR TITLE
Hostname, Cluster and Service Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## NEXT
+
+### Added
+
+- Added metadata optional decoration for entity metrics (`hostname`, 
+  `clusterName` and `serviceName`), [check doc](/docs/entity-definition.md)
+
 ## 3.0.3
 
 ### Changed

--- a/args/args.go
+++ b/args/args.go
@@ -14,14 +14,15 @@ import (
 // DefaultArgumentList includes the minimal set of necessary arguments for an integration.
 // If all data flags (Inventory, Metrics and Events) are false, all of them are published.
 type DefaultArgumentList struct {
-	Verbose    bool   `default:"false" help:"Print more information to logs."`
-	Pretty     bool   `default:"false" help:"Print pretty formatted JSON."`
-	Metrics    bool   `default:"false" help:"Publish metrics data."`
-	Inventory  bool   `default:"false" help:"Publish inventory data."`
-	Events     bool   `default:"false" help:"Publish events data."`
-	Metadata   bool   `default:"false" help:"Add customer defined key-value attributes to the samples."`
-	NriCluster string `default:"" help:"Optional. Cluster name"`
-	NriService string `default:"" help:"Optional. Service name"`
+	Verbose        bool   `default:"false" help:"Print more information to logs."`
+	Pretty         bool   `default:"false" help:"Print pretty formatted JSON."`
+	Metrics        bool   `default:"false" help:"Publish metrics data."`
+	Inventory      bool   `default:"false" help:"Publish inventory data."`
+	Events         bool   `default:"false" help:"Publish events data."`
+	Metadata       bool   `default:"false" help:"Add customer defined key-value attributes to the samples."`
+	NriAddHostname bool   `default:"false" help:"Add hostname attribute to the samples."`
+	NriCluster     string `default:"" help:"Optional. Cluster name"`
+	NriService     string `default:"" help:"Optional. Service name"`
 }
 
 // All returns if all data should be published

--- a/args/args.go
+++ b/args/args.go
@@ -14,12 +14,14 @@ import (
 // DefaultArgumentList includes the minimal set of necessary arguments for an integration.
 // If all data flags (Inventory, Metrics and Events) are false, all of them are published.
 type DefaultArgumentList struct {
-	Verbose   bool `default:"false" help:"Print more information to logs."`
-	Pretty    bool `default:"false" help:"Print pretty formatted JSON."`
-	Metrics   bool `default:"false" help:"Publish metrics data."`
-	Inventory bool `default:"false" help:"Publish inventory data."`
-	Events    bool `default:"false" help:"Publish events data."`
-	Metadata  bool `default:"false" help:"Add customer defined key-value attributes to the samples."`
+	Verbose    bool   `default:"false" help:"Print more information to logs."`
+	Pretty     bool   `default:"false" help:"Print pretty formatted JSON."`
+	Metrics    bool   `default:"false" help:"Publish metrics data."`
+	Inventory  bool   `default:"false" help:"Publish inventory data."`
+	Events     bool   `default:"false" help:"Publish events data."`
+	Metadata   bool   `default:"false" help:"Add customer defined key-value attributes to the samples."`
+	NriCluster string `default:"" help:"Optional. Cluster name"`
+	NriService string `default:"" help:"Optional. Service name"`
 }
 
 // All returns if all data should be published

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -23,6 +23,7 @@ func TestSetupArgsDefault(t *testing.T) {
 	var args argumentList
 
 	os.Setenv("HOSTNAME", "")
+	defer os.Clearenv()
 	os.Args = []string{"cmd"}
 
 	clearFlagSet()
@@ -52,6 +53,7 @@ func TestSetupArgsCommandLine(t *testing.T) {
 	var args argumentList
 
 	os.Setenv("HOSTNAME", "")
+	defer os.Clearenv()
 	os.Args = []string{
 		"cmd",
 		"-verbose",
@@ -98,6 +100,7 @@ func TestSetupArgsEnvironment(t *testing.T) {
 	os.Setenv("HOSTNAME", "otherhost")
 	os.Setenv("PORT", "1234")
 	os.Setenv("CONFIG", "{\"arg1\": 2}")
+	defer os.Clearenv()
 	os.Args = []string{"cmd"}
 
 	clearFlagSet()
@@ -118,6 +121,7 @@ func TestCliArgsOverrideEnvironmentArgs(t *testing.T) {
 	}
 
 	os.Setenv("VERBOSE", "false")
+	defer os.Clearenv()
 	os.Args = []string{
 		"cmd",
 		"-verbose",
@@ -140,6 +144,58 @@ func TestMetadataFlag(t *testing.T) {
 	assert.NoError(t, sdk_args.SetupArgs(&args))
 
 	assert.True(t, args.Metadata)
+}
+
+func TestClusterFlagViaCli(t *testing.T) {
+	os.Args = []string{
+		"cmd",
+		"-nri_cluster=foo",
+	}
+
+	clearFlagSet()
+	var args sdk_args.DefaultArgumentList
+	assert.NoError(t, sdk_args.SetupArgs(&args))
+
+	assert.Equal(t, "foo", args.NriCluster)
+}
+
+func TestClusterFlagViaEnvVar(t *testing.T) {
+	var args sdk_args.DefaultArgumentList
+
+	os.Setenv("NRI_CLUSTER", "bar")
+	defer os.Clearenv()
+	os.Args = []string{"cmd"}
+	clearFlagSet()
+
+	assert.NoError(t, sdk_args.SetupArgs(&args))
+
+	assert.Equal(t, "bar", args.NriCluster)
+}
+
+func TestServiceFlagViaCli(t *testing.T) {
+	os.Args = []string{
+		"cmd",
+		"-nri_service=foo",
+	}
+
+	clearFlagSet()
+	var args sdk_args.DefaultArgumentList
+	assert.NoError(t, sdk_args.SetupArgs(&args))
+
+	assert.Equal(t, "foo", args.NriService)
+}
+
+func TestServiceFlagViaEnvVar(t *testing.T) {
+	var args sdk_args.DefaultArgumentList
+
+	os.Setenv("NRI_SERVICE", "bar")
+	defer os.Clearenv()
+	os.Args = []string{"cmd"}
+
+	clearFlagSet()
+	assert.NoError(t, sdk_args.SetupArgs(&args))
+
+	assert.Equal(t, "bar", args.NriService)
 }
 
 func TestSetupArgsErrors(t *testing.T) {

--- a/docs/entity-definition.md
+++ b/docs/entity-definition.md
@@ -18,7 +18,7 @@ An engineer installs the infrastructure agent on host1 and configures the out-of
 
 ### Metadata decoration
 
-Entity metrics could be decorated with metadata.
+Since [agent v1.0.1052](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-101052) entity metrics could be decorated with metadata.
 
 At the moment integrations can only decorate their entities metrics with `hostname`, `clusterName` and `serviceName`.
 These are all optional decoration values provided via [args](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/toolset/args.md)

--- a/docs/entity-definition.md
+++ b/docs/entity-definition.md
@@ -15,3 +15,10 @@ For Example:
 An engineer installs the infrastructure agent on host1 and configures the out-of-the-box mysql integration to monitor a MySQL server running on host2. Host1 would be an entity as far as the Infrastructure entity is concerned and the MySQL servers on Host2 would be a “remote entity”.
  
 An engineer installs the infrastructure agent on host1 and configures the out-of-the-box kubernetes integration and collects metrics and inventory about the whole cluster, replica sets, pods and nodes.
+
+### Metadata decoration
+
+Entity metrics could be decorated with metadata.
+
+At the moment integrations can only decorate their entities metrics with `hostname`, `clusterName` and `serviceName`.
+These are all optional decoration values provided via [args](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/toolset/args.md)

--- a/docs/toolset/args.md
+++ b/docs/toolset/args.md
@@ -30,6 +30,9 @@ consider. All of them are `bool` and default to `false`. They are described foll
 * `Metrics`: whether the integration should publish metrics' data.
 * `Pretty`: whether the output JSON must be pretty-formatted.
 * `Verbose`: whether the integration should log extra, detailed information.
+* `NriAddHostname`: if true, agent will decorate all the metrics with the `hostname`.
+* `NriCluster`: if any value is provided, all the metrics will be decorated with `clusterName: value`. 
+* `NriService`: if any value is provided, all the metrics will be decorated with `serviceName: value`. 
 
 An example of
 

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewEntity(t *testing.T) {
-	e, err := newEntity("name", "type", persist.NewInMemoryStore())
+	e, err := newEntity("name", "type", persist.NewInMemoryStore(), false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "name", e.Metadata.Name)
@@ -22,13 +22,13 @@ func TestNewEntity(t *testing.T) {
 }
 
 func TestEntitiesRequireNameAndType(t *testing.T) {
-	_, err := newEntity("", "", nil)
+	_, err := newEntity("", "", nil, false)
 
 	assert.Error(t, err)
 }
 
 func TestAddNotificationEvent(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
+	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestAddNotificationEvent(t *testing.T) {
 }
 
 func TestAddNotificationWithEmptySummaryFails(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
+	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestAddNotificationWithEmptySummaryFails(t *testing.T) {
 }
 
 func TestAddEvent_Entity(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
+	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestAddEvent_Entity(t *testing.T) {
 }
 
 func TestAddEvent(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
+	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	assert.NoError(t, err)
 
 	err = en.AddEvent(event.New("TestSummary", ""))
@@ -89,7 +89,7 @@ func TestAddEvent(t *testing.T) {
 }
 
 func TestAddEvent_Entity_EmptySummary_Error(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
+	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	assert.NoError(t, err)
 
 	err = en.AddEvent(event.New("", "TestCategory"))
@@ -99,7 +99,7 @@ func TestAddEvent_Entity_EmptySummary_Error(t *testing.T) {
 }
 
 func TestEntity_AddInventoryConcurrent(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore())
+	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	assert.NoError(t, err)
 
 	itemsAmount := 100
@@ -117,7 +117,7 @@ func TestEntity_AddInventoryConcurrent(t *testing.T) {
 }
 
 func TestEntity_DefaultEntityIsNotSerialized(t *testing.T) {
-	e := newLocalEntity(persist.NewInMemoryStore())
+	e := newLocalEntity(persist.NewInMemoryStore(), false)
 	j, err := json.Marshal(e)
 
 	assert.NoError(t, err)
@@ -125,7 +125,7 @@ func TestEntity_DefaultEntityIsNotSerialized(t *testing.T) {
 }
 
 func TestEntity_IsDefaultEntity(t *testing.T) {
-	e := newLocalEntity(persist.NewInMemoryStore())
+	e := newLocalEntity(persist.NewInMemoryStore(), false)
 
 	assert.Empty(t, e.Metadata, "default entity should have no identifier")
 	assert.True(t, e.isLocalEntity())

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -34,6 +34,7 @@ type Integration struct {
 	ProtocolVersion    string    `json:"protocol_version"`
 	IntegrationVersion string    `json:"integration_version"`
 	Entities           []*Entity `json:"data"`
+	addHostnameToMeta  bool
 	locker             sync.Locker
 	storer             persist.Storer
 	prettyOutput       bool
@@ -80,6 +81,7 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 	}
 	defaultArgs := args.GetDefaultArgs(i.args)
 	i.prettyOutput = defaultArgs.Pretty
+	i.addHostnameToMeta = defaultArgs.NriAddHostname
 
 	// Setting default values, if not set yet
 	if i.logger == nil {
@@ -108,7 +110,7 @@ func (i *Integration) LocalEntity() *Entity {
 		}
 	}
 
-	e := newLocalEntity(i.storer)
+	e := newLocalEntity(i.storer, i.addHostnameToMeta)
 
 	i.Entities = append(i.Entities, e)
 
@@ -127,7 +129,7 @@ func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
 		}
 	}
 
-	e, err = newEntity(name, namespace, i.storer)
+	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -19,8 +19,8 @@ import (
 // Custom attribute keys:
 const (
 	CustomAttrPrefix  = "NRI_"
-	CustomAttrCluster = "NRI_CLUSTER"
-	CustomAttrService = "NRI_SERVICE"
+	CustomAttrCluster = "cluster_name"
+	CustomAttrService = "service_name"
 )
 
 // NR infrastructure agent protocol version

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -16,7 +16,17 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/persist"
 )
 
-const protocolVersion = "2"
+// Custom attribute keys:
+const (
+	CustomAttrPrefix  = "NRI_"
+	CustomAttrCluster = "NRI_CLUSTER"
+	CustomAttrService = "NRI_SERVICE"
+)
+
+// NR infrastructure agent protocol version
+const (
+	protocolVersion = "2"
+)
 
 // Integration defines the format of the output JSON that integrations will return for protocol 2.
 type Integration struct {
@@ -127,11 +137,18 @@ func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
 	if defaultArgs.Metadata {
 		for _, element := range os.Environ() {
 			variable := strings.Split(element, "=")
-			prefix := fmt.Sprintf("NRI_%s_", strings.ToUpper(i.Name))
+			prefix := fmt.Sprintf("%s%s_", CustomAttrPrefix, strings.ToUpper(i.Name))
 			if strings.HasPrefix(variable[0], prefix) {
 				e.setCustomAttribute(strings.TrimPrefix(variable[0], prefix), variable[1])
 			}
 		}
+	}
+
+	if defaultArgs.NriCluster != "" {
+		e.setCustomAttribute(CustomAttrCluster, defaultArgs.NriCluster)
+	}
+	if defaultArgs.NriService != "" {
+		e.setCustomAttribute(CustomAttrService, defaultArgs.NriService)
 	}
 
 	i.Entities = append(i.Entities, e)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -128,6 +128,23 @@ func TestClusterAndServiceArgumentsAreAddedToMetadata(t *testing.T) {
 	}, e.customAttributes)
 }
 
+func TestAddHostnameFlagDecoratesEntities(t *testing.T) {
+	al := sdk_args.DefaultArgumentList{}
+
+	os.Args = []string{"cmd", "-nri_add_hostname"}
+	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
+
+	i, err := New("TestIntegration", "1.0", Logger(log.Discard), Writer(ioutil.Discard), Args(&al))
+	assert.NoError(t, err)
+
+	assert.True(t, i.LocalEntity().AddHostname)
+
+	e, err := i.Entity("name", "ns")
+	assert.NoError(t, err)
+
+	assert.True(t, e.AddHostname)
+}
+
 func TestCustomArguments(t *testing.T) {
 	type argumentList struct {
 		sdk_args.DefaultArgumentList


### PR DESCRIPTION
#### Description of the changes

With the move to remote entities, we've impacted our usability by making it difficult to organize integration data.

This solution provides a way to attach meta data that would be useful to provide the best user experience that can be definable from the agent config file, env-var or directly cli-arg to the integration.

- `NRI_CLUSTER` env-var or `-nri_service` cli flag: an optional attribute that could be either stated by the user or set by a developer. Ideally this would be the name for a kafka cluster etc.
- `NRI_SERVICE` env-var or `-nri_service` cli flag: to label services
- `NRI_ADD_HOSTNAME` env-var or `nri_add_hostname` cli flag: for the agent to decorate samples with the hostname

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
