### PR TITLE
IHOST-1557: Check go version and decide if golint is used or not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-#  - 1.7.x until we skip golint on this version
-#  - 1.8.x until we skip golint on this version
+  - 1.7.x
+  - 1.8.x
   - 1.9.x
   - 1.10.x
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-GOTOOLS = golang.org/x/lint/golint \
-          gopkg.in/alecthomas/gometalinter.v2 \
+GO_VERSION = $(shell go version | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
+
+GOTOOLS = gopkg.in/alecthomas/gometalinter.v2 \
           github.com/axw/gocov/gocov \
           github.com/AlekSi/gocov-xml \
+
+# golint only supports the last two Go versions, update the value when its not supported anymore.
+GOLINT_MIN_GO_VERSION = 1.9
+
+# If GO_VERSION is equal or higher than the GOLINT_MIN_GO_VERSION we use golint.
+ifeq ($(GO_VERSION),$(shell echo "$(GOLINT_MIN_GO_VERSION)\n$(GO_VERSION)" | sort -V | tail -n1))
+	GOTOOLS += golang.org/x/lint/golint
+endif
 
 # Temporary patch to avoid build failing because of the outdated documentation example
 PKGS = $(shell go list ./... | egrep -v "\/docs\/|jmx")


### PR DESCRIPTION
#### Description of the changes

Build fails on Go v1.7 & v1.8 because golint only supports the last to versions of golang.
The fix will check the current installed version of go to decide if golint tool will be used or not.

https://newrelic.atlassian.net/browse/IHOST-1557

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
