### PR TITLE
Added documentation for integration name

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -90,7 +90,7 @@ You will receive the following output
 Initialize an integration generating a scaffold.
 
 Usage:
-  nr-integrations-builder init [integration name] [flags]
+  nr-integrations-builder init [integration_name] [flags]
 
 Flags:
   -n, --company-name string       Company name (required)
@@ -104,6 +104,8 @@ Global Flags:
       --verbose         verbose output
 ```
 It's obligatory to specify `company-name` and `company-prefix` flags. Otherwise, the `nr-integrations-builder` will not initialize the integration.
+
+Keep in mind the builder will use the `integration_name` for auto generating golang files. For this reason choose a name following the [golang naming convention](https://blog.golang.org/package-names).
 
 To initialize the integration and generate the scaffold, run
 ```bash


### PR DESCRIPTION
#### Description of the changes
During the tutorial I realised that the **integration_name** needs to be in camel case following the golang naming conventions. Otherwise it returns an error when it validates the code with gometalinter.v2.

I added a small comment explaining this.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
