### PR TITLE
Adding arguments for SSL option for JMX connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can easily fetch it using:
 ### JMX support
 
 The Integrations Go lang SDK supports getting metrics through JMX by calling the
-`jmx.Open()`, `jmx.Query()` and `jmx.Close()` functions. This JMX support relies
+`jmx.Open()`, `jmx.OpenWithSSL`, `jmx.Query()` and `jmx.Close()` functions. This JMX support relies
 on the nrjmx tool. Follow the steps in
 the [nrjmx](https://github.com/newrelic/nrjmx) repository to build it and set
 the `NR_JMX_TOOL` environment variable to point to the location of the nrjmx

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -39,7 +39,7 @@ const (
 	jmxLineBuffer = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
 )
 
-func getCommand(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd string) []string {
+func getCommand(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string) []string {
 	var cliCommand []string
 
 	if os.Getenv("NR_JMX_TOOL") != "" {
@@ -53,11 +53,15 @@ func getCommand(hostname, port, username, password, keyStore, keyStorePwd, trust
 		cliCommand = append(cliCommand, "--username", username, "--password", password)
 	}
 
+	if keyStore != "" && keyStorePassword != "" && trustStore != "" && trustStorePassword != "" {
+		cliCommand = append(cliCommand, "--keyStore", keyStore, "--keyStorePassword", keyStorePassword, "--trustStore", trustStore, "--trustStorePassword", trustStorePassword)
+	}
+
 	return cliCommand
 }
 
 // Open will start the nrjmx command with the provided connection parameters.
-func Open(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trsutStorePwd string) error {
+func Open(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string) error {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -75,7 +79,7 @@ func Open(hostname, port, username, password, keyStore, keyStorePwd, trustStore,
 	var err error
 	var ctx context.Context
 
-	cliCommand := getCommand(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trsutStorePwd)
+	cliCommand := getCommand(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cmd = exec.CommandContext(ctx, cliCommand[0], cliCommand[1:]...)

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -39,7 +39,7 @@ const (
 	jmxLineBuffer = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
 )
 
-func getCommand(hostname, port, username, password string) []string {
+func getCommand(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd string) []string {
 	var cliCommand []string
 
 	if os.Getenv("NR_JMX_TOOL") != "" {
@@ -57,7 +57,7 @@ func getCommand(hostname, port, username, password string) []string {
 }
 
 // Open will start the nrjmx command with the provided connection parameters.
-func Open(hostname, port, username, password string) error {
+func Open(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trsutStorePwd string) error {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -75,7 +75,7 @@ func Open(hostname, port, username, password string) error {
 	var err error
 	var ctx context.Context
 
-	cliCommand := getCommand(hostname, port, username, password)
+	cliCommand := getCommand(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trsutStorePwd)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cmd = exec.CommandContext(ctx, cliCommand[0], cliCommand[1:]...)

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -57,11 +57,22 @@ func TestMain(m *testing.M) {
 func TestJmxOpen(t *testing.T) {
 	defer Close()
 
-	if err := Open("", "", "", "", "", "", "", ""); err != nil {
+	if err := Open("", "", "", ""); err != nil {
 		t.Error(err)
 	}
 
-	if Open("", "", "", "", "", "", "", "") == nil {
+	if Open("", "", "", "") == nil {
+		t.Error()
+	}
+}
+func TestJmxOpenWithSSL(t *testing.T) {
+	defer Close()
+
+	if err := OpenWithSSL("", "", "", "", "", "", "", ""); err != nil {
+		t.Error(err)
+	}
+
+	if OpenWithSSL("", "", "", "", "", "", "", "") == nil {
 		t.Error()
 	}
 }
@@ -69,7 +80,18 @@ func TestJmxOpen(t *testing.T) {
 func TestJmxQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", openAttempts); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("empty", timeout); err != nil {
+		t.Error(err)
+	}
+}
+func TestJmxQueryWithSSL(t *testing.T) {
+	defer Close()
+
+	if err := openWaitWithSSL("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -81,7 +103,18 @@ func TestJmxQuery(t *testing.T) {
 func TestJmxCrashQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", openAttempts); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("crash", timeout); err == nil {
+		t.Error()
+	}
+}
+func TestJmxCrashQueryWithSSL(t *testing.T) {
+	defer Close()
+
+	if err := openWaitWithSSL("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -93,7 +126,18 @@ func TestJmxCrashQuery(t *testing.T) {
 func TestJmxInvalidQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", openAttempts); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("invalid", timeout); err == nil {
+		t.Error()
+	}
+}
+func TestJmxInvalidQueryWithSSL(t *testing.T) {
+	defer Close()
+
+	if err := openWaitWithSSL("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -105,7 +149,22 @@ func TestJmxInvalidQuery(t *testing.T) {
 func TestJmxTimeoutQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", openAttempts); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("timeout", timeout); err == nil {
+		t.Error()
+	}
+
+	if _, err := Query("empty", timeout); err == nil {
+		t.Error()
+	}
+}
+func TestJmxTimeoutQueryWithSSL(t *testing.T) {
+	defer Close()
+
+	if err := openWaitWithSSL("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -123,7 +182,20 @@ func TestJmxNoTimeoutQuery(t *testing.T) {
 
 	defer Close()
 
-	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", openAttempts); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("timeout", 1500); err != nil {
+		t.Error(err)
+	}
+}
+func TestJmxNoTimeoutQueryWithSSL(t *testing.T) {
+	t.Skip("unreliable CI test")
+
+	defer Close()
+
+	if err := openWaitWithSSL("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -137,7 +209,24 @@ func TestJmxTimeoutBigQuery(t *testing.T) {
 
 	defer Close()
 
-	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", openAttempts); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("bigPayload", timeout); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := Query("bigPayloadError", timeout); err == nil {
+		t.Error()
+	}
+}
+func TestJmxTimeoutBigQueryWithSSL(t *testing.T) {
+	t.Skip("unreliable CI test")
+
+	defer Close()
+
+	if err := openWaitWithSSL("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -151,13 +240,25 @@ func TestJmxTimeoutBigQuery(t *testing.T) {
 }
 
 // tests can overlap, and as jmx-cmd is a singleton, waiting for it to be closed is mandatory
-func openWait(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string, attempts int) error {
-	err := Open(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword)
+func openWait(hostname, port, username, password string, attempts int) error {
+	err := Open(hostname, port, username, password)
 	if err == ErrJmxCmdRunning && attempts > 0 {
 		attempts--
 		time.Sleep(10 * time.Millisecond)
 
-		return openWait(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword, attempts)
+		return openWait(hostname, port, username, password, attempts)
+	}
+
+	return err
+}
+
+func openWaitWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string, attempts int) error {
+	err := OpenWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword)
+	if err == ErrJmxCmdRunning && attempts > 0 {
+		attempts--
+		time.Sleep(10 * time.Millisecond)
+
+		return openWaitWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword, attempts)
 	}
 
 	return err

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -57,11 +57,11 @@ func TestMain(m *testing.M) {
 func TestJmxOpen(t *testing.T) {
 	defer Close()
 
-	if err := Open("", "", "", ""); err != nil {
+	if err := Open("", "", "", "", "", "", "", ""); err != nil {
 		t.Error(err)
 	}
 
-	if Open("", "", "", "") == nil {
+	if Open("", "", "", "", "", "", "", "") == nil {
 		t.Error()
 	}
 }
@@ -69,7 +69,7 @@ func TestJmxOpen(t *testing.T) {
 func TestJmxQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -81,7 +81,7 @@ func TestJmxQuery(t *testing.T) {
 func TestJmxCrashQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -93,7 +93,7 @@ func TestJmxCrashQuery(t *testing.T) {
 func TestJmxInvalidQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -105,7 +105,7 @@ func TestJmxInvalidQuery(t *testing.T) {
 func TestJmxTimeoutQuery(t *testing.T) {
 	defer Close()
 
-	if err := openWait("", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -123,7 +123,7 @@ func TestJmxNoTimeoutQuery(t *testing.T) {
 
 	defer Close()
 
-	if err := openWait("", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -137,7 +137,7 @@ func TestJmxTimeoutBigQuery(t *testing.T) {
 
 	defer Close()
 
-	if err := openWait("", "", "", "", openAttempts); err != nil {
+	if err := openWait("", "", "", "", "", "", "", "", openAttempts); err != nil {
 		t.Error(err)
 	}
 
@@ -151,13 +151,13 @@ func TestJmxTimeoutBigQuery(t *testing.T) {
 }
 
 // tests can overlap, and as jmx-cmd is a singleton, waiting for it to be closed is mandatory
-func openWait(hostname, port, username, password string, attempts int) error {
-	err := Open(hostname, port, username, password)
+func openWait(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd string, attempts int) error {
+	err := Open(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd)
 	if err == ErrJmxCmdRunning && attempts > 0 {
 		attempts--
 		time.Sleep(10 * time.Millisecond)
 
-		return openWait(hostname, port, username, password, attempts)
+		return openWait(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd, attempts)
 	}
 
 	return err

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -151,13 +151,13 @@ func TestJmxTimeoutBigQuery(t *testing.T) {
 }
 
 // tests can overlap, and as jmx-cmd is a singleton, waiting for it to be closed is mandatory
-func openWait(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd string, attempts int) error {
-	err := Open(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd)
+func openWait(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string, attempts int) error {
+	err := Open(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword)
 	if err == ErrJmxCmdRunning && attempts > 0 {
 		attempts--
 		time.Sleep(10 * time.Millisecond)
 
-		return openWait(hostname, port, username, password, keyStore, keyStorePwd, trustStore, trustStorePwd, attempts)
+		return openWait(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword, attempts)
 	}
 
 	return err


### PR DESCRIPTION
#### Description of the changes
Customer requests to use JMX OHI over SSL. I am adding SSL arguments to the wrapper to nrmjx - the related PR to modify nrjmx is https://github.com/newrelic/nrjmx/pull/11 

#### PR Review Checklist
### Vinod Vydier
- [impacts any OHI using JMX] 
- [Added certs in the environment when making the JMX connect call. nr-jmx wrapper use Jmx.Open in the SDK that needs to be updated for nr-jmx send SSL arguments to nrjmx ] 
