### PR TITLE
Make cluster and service entity attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - SSL support for jmx package. Explained at https://github.com/newrelic/infra-integrations-sdk#jmx-support
 
+## Next Release
+
+### Changed
+
+- Protocol v2.1. NriCluster and NriService are set as entity attributes,
+  instead of decorating every sample.
+
 ## 3.1.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next Release
+
+### Added
+
+- Protocol v3. NriCluster and NriService are set as entity metadata fields,
+  instead of entity custom attributes.
+
 ## 3.1.1
 
 ### Added
 
 - SSL support for jmx package. Explained at https://github.com/newrelic/infra-integrations-sdk#jmx-support
-
-## Next Release
-
-### Changed
-
-- Protocol v2.1. NriCluster and NriService are set as entity attributes,
-  instead of decorating every sample.
 
 ## 3.1.0
 

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -14,21 +14,31 @@ import (
 )
 
 func TestNewEntity(t *testing.T) {
-	e, err := newEntity("name", "type", persist.NewInMemoryStore(), false)
+	e, err := newInMemoryEntity("name", "type")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "name", e.Metadata.Name)
 	assert.Equal(t, "type", e.Metadata.Namespace)
+	assert.False(t, e.AddHostname)
+}
+
+func TestNewEntityWithAttributes(t *testing.T) {
+	e, err := newEntity("name", "type", persist.NewInMemoryStore(), true, "cluster-name", "service-name")
+
+	assert.NoError(t, err)
+	assert.True(t, e.AddHostname)
+	assert.Equal(t, "cluster-name", e.Cluster)
+	assert.Equal(t, "service-name", e.Service)
 }
 
 func TestEntitiesRequireNameAndType(t *testing.T) {
-	_, err := newEntity("", "", nil, false)
+	_, err := newInMemoryEntity("", "")
 
 	assert.Error(t, err)
 }
 
 func TestAddNotificationEvent(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
+	en, err := newInMemoryEntity("Entity1", "Type1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +54,7 @@ func TestAddNotificationEvent(t *testing.T) {
 }
 
 func TestAddNotificationWithEmptySummaryFails(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
+	en, err := newInMemoryEntity("Entity1", "Type1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +66,7 @@ func TestAddNotificationWithEmptySummaryFails(t *testing.T) {
 }
 
 func TestAddEvent_Entity(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
+	en, err := newInMemoryEntity("Entity1", "Type1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +86,7 @@ func TestAddEvent_Entity(t *testing.T) {
 }
 
 func TestAddEvent(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
+	en, err := newInMemoryEntity("Entity1", "Type1")
 	assert.NoError(t, err)
 
 	err = en.AddEvent(event.New("TestSummary", ""))
@@ -89,7 +99,7 @@ func TestAddEvent(t *testing.T) {
 }
 
 func TestAddEvent_Entity_EmptySummary_Error(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
+	en, err := newInMemoryEntity("Entity1", "Type1")
 	assert.NoError(t, err)
 
 	err = en.AddEvent(event.New("", "TestCategory"))
@@ -99,7 +109,7 @@ func TestAddEvent_Entity_EmptySummary_Error(t *testing.T) {
 }
 
 func TestEntity_AddInventoryConcurrent(t *testing.T) {
-	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
+	en, err := newInMemoryEntity("Entity1", "Type1")
 	assert.NoError(t, err)
 
 	itemsAmount := 100
@@ -129,4 +139,12 @@ func TestEntity_IsDefaultEntity(t *testing.T) {
 
 	assert.Empty(t, e.Metadata, "default entity should have no identifier")
 	assert.True(t, e.isLocalEntity())
+}
+
+// newEntity creates a new remote-entity with in-memory store and empty entity attributes.
+func newInMemoryEntity(
+	name,
+	namespace string,
+) (*Entity, error) {
+	return newEntity(name, namespace, persist.NewInMemoryStore(), false, "", "")
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -128,23 +128,8 @@ func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
 	}
 
 	defaultArgs := args.GetDefaultArgs(i.args)
-	var eOpts []entityOption
 
-	if defaultArgs.NriCluster != "" {
-		eOpts = append(eOpts, func(e *Entity) error {
-			e.Cluster = defaultArgs.NriCluster
-			return nil
-		})
-	}
-
-	if defaultArgs.NriService != "" {
-		eOpts = append(eOpts, func(e *Entity) error {
-			e.Service = defaultArgs.NriService
-			return nil
-		})
-	}
-
-	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta, eOpts...)
+	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta, defaultArgs.NriCluster, defaultArgs.NriService)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -23,7 +23,7 @@ const (
 
 // NR infrastructure agent protocol version
 const (
-	protocolVersion = "2.1"
+	protocolVersion = "3"
 )
 
 // Integration defines the format of the output JSON that integrations will return for protocol 2.

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -23,7 +23,7 @@ const (
 
 // NR infrastructure agent protocol version
 const (
-	protocolVersion = "2"
+	protocolVersion = "2.1"
 )
 
 // Integration defines the format of the output JSON that integrations will return for protocol 2.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -29,7 +29,7 @@ func TestCreation(t *testing.T) {
 	if i.IntegrationVersion != "1.0" {
 		t.Error()
 	}
-	if i.ProtocolVersion != "2" {
+	if i.ProtocolVersion != "2.1" {
 		t.Error()
 	}
 	if len(i.Entities) != 0 {
@@ -52,7 +52,7 @@ func TestDefaultIntegrationWritesToStdout(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "integration", i.Name)
 	assert.Equal(t, "4.0", i.IntegrationVersion)
-	assert.Equal(t, "2", i.ProtocolVersion)
+	assert.Equal(t, "2.1", i.ProtocolVersion)
 	assert.Equal(t, 0, len(i.Entities))
 
 	assert.NoError(t, i.Publish())
@@ -61,7 +61,7 @@ func TestDefaultIntegrationWritesToStdout(t *testing.T) {
 	f.Close()
 	payload, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"4.0","data":[]}`+"\n", string(payload))
+	assert.Equal(t, `{"name":"integration","protocol_version":"2.1","integration_version":"4.0","data":[]}`+"\n", string(payload))
 }
 
 func TestIntegration_DefaultEntity(t *testing.T) {
@@ -84,7 +84,7 @@ func TestDefaultArguments(t *testing.T) {
 	if i.IntegrationVersion != "1.0" {
 		t.Error()
 	}
-	if i.ProtocolVersion != "2" {
+	if i.ProtocolVersion != "2.1" {
 		t.Error()
 	}
 	if len(i.Entities) != 0 {
@@ -248,7 +248,7 @@ func TestIntegration_Publish(t *testing.T) {
 			expectedOutputRaw := []byte(`
 			{
 			  "name": "TestIntegration",
-			  "protocol_version": "2",
+			  "protocol_version": "2.1",
 			  "integration_version": "1.0",
 			  "data": [
 				{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -29,7 +29,7 @@ func TestCreation(t *testing.T) {
 	if i.IntegrationVersion != "1.0" {
 		t.Error()
 	}
-	if i.ProtocolVersion != "2.1" {
+	if i.ProtocolVersion != "3" {
 		t.Error()
 	}
 	if len(i.Entities) != 0 {
@@ -52,7 +52,7 @@ func TestDefaultIntegrationWritesToStdout(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "integration", i.Name)
 	assert.Equal(t, "4.0", i.IntegrationVersion)
-	assert.Equal(t, "2.1", i.ProtocolVersion)
+	assert.Equal(t, "3", i.ProtocolVersion)
 	assert.Equal(t, 0, len(i.Entities))
 
 	assert.NoError(t, i.Publish())
@@ -61,7 +61,7 @@ func TestDefaultIntegrationWritesToStdout(t *testing.T) {
 	f.Close()
 	payload, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, `{"name":"integration","protocol_version":"2.1","integration_version":"4.0","data":[]}`+"\n", string(payload))
+	assert.Equal(t, `{"name":"integration","protocol_version":"3","integration_version":"4.0","data":[]}`+"\n", string(payload))
 }
 
 func TestIntegration_DefaultEntity(t *testing.T) {
@@ -84,7 +84,7 @@ func TestDefaultArguments(t *testing.T) {
 	if i.IntegrationVersion != "1.0" {
 		t.Error()
 	}
-	if i.ProtocolVersion != "2.1" {
+	if i.ProtocolVersion != "3" {
 		t.Error()
 	}
 	if len(i.Entities) != 0 {
@@ -248,7 +248,7 @@ func TestIntegration_Publish(t *testing.T) {
 			expectedOutputRaw := []byte(`
 			{
 			  "name": "TestIntegration",
-			  "protocol_version": "2.1",
+			  "protocol_version": "3",
 			  "integration_version": "1.0",
 			  "data": [
 				{

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -25,7 +25,7 @@ func TestWriter(t *testing.T) {
 
 	assert.NoError(t, i.Publish())
 
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"7.0","data":[]}`+"\n", w.String())
+	assert.Equal(t, `{"name":"integration","protocol_version":"2.1","integration_version":"7.0","data":[]}`+"\n", w.String())
 }
 
 func TestArgs(t *testing.T) {

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -25,7 +25,7 @@ func TestWriter(t *testing.T) {
 
 	assert.NoError(t, i.Publish())
 
-	assert.Equal(t, `{"name":"integration","protocol_version":"2.1","integration_version":"7.0","data":[]}`+"\n", w.String())
+	assert.Equal(t, `{"name":"integration","protocol_version":"3","integration_version":"7.0","data":[]}`+"\n", w.String())
 }
 
 func TestArgs(t *testing.T) {


### PR DESCRIPTION
#### Description of the changes

Make the cluster and service entity attributes instead of setting them as custom attributes.

This change will depend on the agent doing the cluster and service decoration. Integrations made with this version of the SDK should have a clear version dependency with the agent version that implements this feature, to not break backwards compatibility, meaning stop decorating metrics with this values.

Also review the documentation draft. https://docs.newrelic.com/node/12561/draft

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
