### PR TITLE
Protocol V3: Added identifier attributes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added metadata optional decoration for entity metrics (`hostname` and attributes), [check doc](/docs/entity-definition.md)
+- Added metadata optional decoration for entity metrics (`hostname`), [check doc](/docs/entity-definition.md)
+- Added `identifier attributes` for entity metadata.
 
 ## 3.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added metadata optional decoration for entity metrics (`hostname`, 
-  `clusterName` and `serviceName`), [check doc](/docs/entity-definition.md)
+- Added metadata optional decoration for entity metrics (`hostname` and attributes), [check doc](/docs/entity-definition.md)
 
 ## 3.0.3
 

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"errors"
-	"sort"
 	"sync"
 
 	"github.com/newrelic/infra-integrations-sdk/data/event"
@@ -24,14 +23,14 @@ type Entity struct {
 	customAttributes []metric.Attribute
 }
 
-//SortedIDAttributes this sorted list ensures uniqueness for the entity Key.
-type SortedIDAttributes []IDAttribute
+//IDAttributes used for the entity key uniqueness
+type IDAttributes []IDAttribute
 
 // EntityMetadata stores entity Metadata
 type EntityMetadata struct {
-	Name      string             `json:"name"`
-	Namespace string             `json:"type"`          // For compatibility reasons we keep the type.
-	IDAttrs   SortedIDAttributes `json:"id_attributes"` // For entity Key uniqueness
+	Name      string       `json:"name"`
+	Namespace string       `json:"type"`          // For compatibility reasons we keep the type.
+	IDAttrs   IDAttributes `json:"id_attributes"` // For entity Key uniqueness
 }
 
 // newLocalEntity creates unique default entity without identifier (name & type)
@@ -71,47 +70,23 @@ func newEntity(
 		Metadata: &EntityMetadata{
 			Name:      name,
 			Namespace: namespace,
-			IDAttrs:   sortIDAttributes(idAttrs...),
+			IDAttrs:   idAttributes(idAttrs...),
 		},
 	}
 
 	return &d, nil
 }
 
-//IDAttributesSorter ...
-type IDAttributesSorter struct {
-	IDAttributes SortedIDAttributes
-}
-
-// Len is part of sort.Interface.
-func (s *IDAttributesSorter) Len() int {
-	return len(s.IDAttributes)
-}
-
-// Swap is part of sort.Interface.
-func (s *IDAttributesSorter) Swap(i, j int) {
-	s.IDAttributes[i], s.IDAttributes[j] = s.IDAttributes[j], s.IDAttributes[i]
-}
-
-// Less is part of sort.Interface.
-func (s *IDAttributesSorter) Less(i, j int) bool {
-	return s.IDAttributes[i].Key < s.IDAttributes[j].Key
-}
-
-func sortIDAttributes(idAttrs ...IDAttribute) SortedIDAttributes {
-	sorted := make(SortedIDAttributes, len(idAttrs))
-	if len(sorted) == 0 {
-		return sorted
+func idAttributes(idAttrs ...IDAttribute) IDAttributes {
+	attrs := make(IDAttributes, len(idAttrs))
+	if len(attrs) == 0 {
+		return attrs
 	}
 	for i, attr := range idAttrs {
-		sorted[i] = attr
+		attrs[i] = attr
 	}
-	sorter := &IDAttributesSorter{
-		IDAttributes: sorted,
-	}
-	sort.Sort(sorter)
 
-	return sorted
+	return attrs
 }
 
 // isLocalEntity returns true if entity is the default one (has no identifier: name & type)

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -56,7 +56,6 @@ func newEntity(
 	idAttrs ...IDAttribute,
 ) (*Entity, error) {
 
-	// If one of the idAttr is defined, both Name and Namespace are needed.
 	if name == "" || namespace == "" {
 		return nil, errors.New("entity name and type are required when defining one")
 	}
@@ -69,13 +68,11 @@ func newEntity(
 		AddHostname: addHostnameToMetadata,
 		storer:      storer,
 		lock:        &sync.Mutex{},
-	}
-
-	// Entity data is optional. When not specified, data from the integration is reported for the agent's own entity.
-	d.Metadata = &EntityMetadata{
-		Name:      name,
-		Namespace: namespace,
-		IDAttrs:   sortIDAttributes(idAttrs...),
+		Metadata: &EntityMetadata{
+			Name:      name,
+			Namespace: namespace,
+			IDAttrs:   sortIDAttributes(idAttrs...),
+		},
 	}
 
 	return &d, nil
@@ -103,6 +100,9 @@ func (s *IDAttributesSorter) Less(i, j int) bool {
 
 func sortIDAttributes(idAttrs ...IDAttribute) SortedIDAttributes {
 	sorted := make(SortedIDAttributes, len(idAttrs))
+	if len(sorted) == 0 {
+		return sorted
+	}
 	for i, attr := range idAttrs {
 		sorted[i] = attr
 	}

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -49,10 +49,10 @@ func newEntity(
 	namespace string,
 	storer persist.Storer,
 	addHostnameToMetadata bool,
-	attributes ...IdentifierAttribute,
+	idAttr ...IdentifierAttribute,
 ) (*Entity, error) {
 
-	// If one of the attributes is defined, both Name and Namespace are needed.
+	// If one of the idAttr is defined, both Name and Namespace are needed.
 	if name == "" || namespace == "" {
 		return nil, errors.New("entity name and type are required when defining one")
 	}
@@ -67,10 +67,10 @@ func newEntity(
 		lock:        &sync.Mutex{},
 	}
 
-	idAttrs := make([]map[string]string, len(attributes))
-	for i := 0; i < len(attributes); i++ {
-		idAttrs[i] = map[string]string{
-			attributes[i].key: attributes[i].value,
+	mapAttr := make([]map[string]string, len(idAttr))
+	for i, attr := range idAttr {
+		mapAttr[i] = map[string]string{
+			attr.key: attr.value,
 		}
 	}
 
@@ -78,7 +78,7 @@ func newEntity(
 	d.Metadata = &EntityMetadata{
 		Name:                 name,
 		Namespace:            namespace,
-		IdentifierAttributes: idAttrs,
+		IdentifierAttributes: mapAttr,
 	}
 
 	return &d, nil

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -58,28 +58,6 @@ func TestNewEntityWithOneAttribute(t *testing.T) {
 	assert.Equal(t, e.Metadata.IDAttrs[0], attr1)
 }
 
-func TestEntity_AttributesAreSortedByKey(t *testing.T) {
-
-	attr1 := NewIDAttribute("aaa", "x")
-	attr2 := NewIDAttribute("bbb", "x")
-	attr3 := NewIDAttribute("ccc", "x")
-	attr4 := NewIDAttribute("ddd", "x")
-	attr5 := NewIDAttribute("zzz", "x")
-
-	expected := SortedIDAttributes{attr1, attr2, attr3, attr4, attr5}
-	attributes := [][]IDAttribute{
-		{attr1, attr2, attr3, attr4, attr5},
-		{attr2, attr3, attr4, attr1, attr5},
-		{attr1, attr5, attr4, attr3, attr2},
-		{attr5, attr4, attr3, attr2, attr1},
-	}
-	for _, attrs := range attributes {
-		e, err := newEntity("name", "type", persist.NewInMemoryStore(), true, attrs...)
-		assert.NoError(t, err)
-		assert.Equal(t, expected, e.Metadata.IDAttrs)
-	}
-}
-
 func TestEntitiesRequireNameAndType(t *testing.T) {
 	_, err := newEntity("", "", nil, false)
 

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -60,13 +60,13 @@ func TestNewEntityWithOneAttribute(t *testing.T) {
 
 func TestEntity_AttributesAreSortedByKey(t *testing.T) {
 
-	attr1 := NewIDAttribute("bbb", "x")
-	attr2 := NewIDAttribute("aaa", "x")
+	attr1 := NewIDAttribute("aaa", "x")
+	attr2 := NewIDAttribute("bbb", "x")
 	attr3 := NewIDAttribute("ccc", "x")
-	attr4 := NewIDAttribute("zzz", "x")
-	attr5 := NewIDAttribute("ddd", "x")
+	attr4 := NewIDAttribute("ddd", "x")
+	attr5 := NewIDAttribute("zzz", "x")
 
-	expected := SortedIDAttributes{attr2, attr1, attr3, attr5, attr4}
+	expected := SortedIDAttributes{attr1, attr2, attr3, attr4, attr5}
 	attributes := [][]IDAttribute{
 		{attr1, attr2, attr3, attr4, attr5},
 		{attr2, attr3, attr4, attr1, attr5},

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -19,6 +19,27 @@ func TestNewEntity(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "name", e.Metadata.Name)
 	assert.Equal(t, "type", e.Metadata.Namespace)
+	assert.False(t, e.AddHostname)
+	assert.Empty(t, e.Metadata.IdentifierAttributes)
+}
+
+func TestNewEntityWithAttributes(t *testing.T) {
+	attr1 := IdentifierAttribute{"env", "prod"}
+	attr2 := IdentifierAttribute{"srv", "auth"}
+	e, err := newEntity(
+		"name",
+		"type",
+		persist.NewInMemoryStore(),
+		true,
+		attr1,
+		attr2,
+	)
+
+	assert.NoError(t, err)
+	assert.True(t, e.AddHostname)
+	assert.Len(t, e.Metadata.IdentifierAttributes, 2)
+	assert.Equal(t, e.Metadata.IdentifierAttributes[0], map[string]string{attr1.key: attr1.value})
+	assert.Equal(t, e.Metadata.IdentifierAttributes[1], map[string]string{attr2.key: attr2.value})
 }
 
 func TestEntitiesRequireNameAndType(t *testing.T) {

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -25,7 +25,7 @@ const (
 
 // NR infrastructure agent protocol version
 const (
-	protocolVersion = "2"
+	protocolVersion = "3"
 )
 
 // Integration defines the format of the output JSON that integrations will return for protocol 2.
@@ -41,6 +41,12 @@ type Integration struct {
 	writer             io.Writer
 	logger             log.Logger
 	args               interface{}
+}
+
+// IdentifierAttribute is a key value struct which is used to have uniqueness during the entity key resolution.
+type IdentifierAttribute struct {
+	key   string
+	value string
 }
 
 // New creates new integration with sane default values.
@@ -118,7 +124,7 @@ func (i *Integration) LocalEntity() *Entity {
 }
 
 // Entity method creates or retrieves an already created entity.
-func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
+func (i *Integration) Entity(name, namespace string, idAttributes ...IdentifierAttribute) (e *Entity, err error) {
 	i.locker.Lock()
 	defer i.locker.Unlock()
 
@@ -129,7 +135,7 @@ func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
 		}
 	}
 
-	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta)
+	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta, idAttributes...)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -43,10 +43,18 @@ type Integration struct {
 	args               interface{}
 }
 
-// IdentifierAttribute is a key value struct which is used to have uniqueness during the entity key resolution.
-type IdentifierAttribute struct {
-	key   string
-	value string
+// IDAttribute is a Key Value struct which is used to have uniqueness during the entity Key resolution.
+type IDAttribute struct {
+	Key   string
+	Value string
+}
+
+// NewIDAttribute creates new identifier attribute.
+func NewIDAttribute(key, value string) IDAttribute {
+	return IDAttribute{
+		Key:   key,
+		Value: value,
+	}
 }
 
 // New creates new integration with sane default values.
@@ -124,7 +132,7 @@ func (i *Integration) LocalEntity() *Entity {
 }
 
 // Entity method creates or retrieves an already created entity.
-func (i *Integration) Entity(name, namespace string, idAttributes ...IdentifierAttribute) (e *Entity, err error) {
+func (i *Integration) Entity(name, namespace string, idAttributes ...IDAttribute) (e *Entity, err error) {
 	i.locker.Lock()
 	defer i.locker.Unlock()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -231,7 +231,10 @@ func TestIntegration_Publish(t *testing.T) {
 					"name": "EntityOne",
 					"type": "test",
 					"id_attributes": [
-					  {"env" : "prod"}
+					  {
+						"Key":"env",
+						"Value":"prod"
+					  }
 					]
 				  },
 				  "metrics": [
@@ -287,7 +290,7 @@ func TestIntegration_Publish(t *testing.T) {
 	i, err := New("TestIntegration", "1.0", Logger(log.Discard), Writer(w))
 	assert.NoError(t, err)
 
-	e, err := i.Entity("EntityOne", "test", IdentifierAttribute{"env", "prod"})
+	e, err := i.Entity("EntityOne", "test", NewIDAttribute("env", "prod"))
 	assert.NoError(t, err)
 	ms := e.NewMetricSet("EventTypeForEntityOne")
 	assert.NoError(t, ms.SetMetric("metricOne", 1, metric.GAUGE))

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -25,7 +25,7 @@ func TestWriter(t *testing.T) {
 
 	assert.NoError(t, i.Publish())
 
-	assert.Equal(t, `{"name":"integration","protocol_version":"2","integration_version":"7.0","data":[]}`+"\n", w.String())
+	assert.Equal(t, `{"name":"integration","protocol_version":"3","integration_version":"7.0","data":[]}`+"\n", w.String())
 }
 
 func TestArgs(t *testing.T) {


### PR DESCRIPTION
New protocol version 3. Added `identifier attributes` in Entity metadata in order to have uniqueness in the entity key.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
