### PR TITLE
Added remote jmx flag for jBoss6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- JMX with optional parameters. Added remote JMX URL protocol option.
+- New JMX open method with optional parameters. Added remote JMX URL protocol option.
+Use `jmx.OpenWithParameters` instead of old removed methods `jmx.OpenWithSSL` and `jmx.Open` 
 
 ## 3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- JMX with optional parameters. Added remote JMX URL protocol option.
+
+## 3.1.2
+
+### Added
+
 - Protocol v3: See full [documentation](docs/protocol-v3.md).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- New JMX open method with optional parameters. Added remote JMX URL protocol option.
-Use `jmx.OpenWithParameters` instead of old removed methods `jmx.OpenWithSSL` and `jmx.Open` 
+- New JMX option for remote URL protocol connections.
+- Changed JMX open method. New `jmx.OpenWithParameters` accepts optionals parameters like SSL, remote connections, etc. Old integrations using old  methods `jmx.OpenWithSSL` and `jmx.Open` should use this new `jmx.OpenWithParameters` method instead. 
 
 ## 3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next Release
 
-### Added
+### Changed
 
 - New JMX open method with optional parameters. Added remote JMX URL protocol option.
 Use `jmx.OpenWithParameters` instead of old removed methods `jmx.OpenWithSSL` and `jmx.Open` 

--- a/docs/toolset/jmx.md
+++ b/docs/toolset/jmx.md
@@ -30,7 +30,9 @@ the [SDK JMX GoDoc page]([http.New GoDoc](https://godoc.org/github.com/newrelic/
 
 * `jmx.Open` ([GoDoc]([http.New GoDoc](https://godoc.org/github.com/newrelic/infra-integrations-sdk/jmx#Open)))
     - Instantiates a JMX client. It requires a `hostname` and a `port` as arguments. `username` and
-      `password` are optional (pass empty strings `""` if no user/password).
+      `password` are optional (pass empty strings `""` if no user/password). There is also the possibility to configure
+     the JMX agent with SSL or configure the remote URL connection using the [Option](https://godoc.org/github.com/newrelic/infra-integrations-sdk/jmx#Option) type.
+     See example below using the SSL configuration.
     - By default, the generated client will look for the [NRJMX tool](#installing-nr-jmx) in the path `/usr/bin/nrjmx`,
       but this location can be overriden by means of the `NR_JMX_TOOL` environment variable.
     - This function will return the global `ErrJmxCmdRunning` error, if there is already another instance of NRJMX
@@ -42,7 +44,7 @@ the [SDK JMX GoDoc page]([http.New GoDoc](https://godoc.org/github.com/newrelic/
        MBean Object Name (in the `domain:key-property-list` form) and the value is the sample value for this metric
        at the given moment.
        
-## Basic usage example
+## Example 1: Basic usage
 
 ```go
 jmx.Open("127.0.0.1", "9010", "", "")
@@ -73,4 +75,24 @@ java.lang:type=OperatingSystem,attr=SystemCpuLoad -> 0.07889343680634009
 java.lang:type=OperatingSystem,attr=AvailableProcessors -> 8
 java.lang:type=OperatingSystem,attr=FreeSwapSpaceSize -> 977272832
 java.lang:type=OperatingSystem,attr=ProcessCpuTime -> 1039197000
+```
+
+# Example 2: Open connection with SSL
+```go
+ssl := WithSSL(
+	"/etc/pki/JMXClientKeyStore.key", 
+	"password_key", 
+	"/etc/pki/JMXClientTrustStore.key", 
+	"password_trust",
+)
+jmx.Open("127.0.0.1", "9010", "", "", ssl)
+```
+
+# Example 3: Remoting protocol for JMX
+Some jBoss versions need the `remoting-jmx` protocol URL. Use `WithRemoteProtocol()` for using this remoting URL.
+- **URL without remoting protocol** `service:jmx:rmi:///jndi/rmi://host:port/jmxrmi`
+- **Remoting URL** `service:jmx:remoting-jmx://host:port`
+
+```go
+jmx.Open("127.0.0.1", "9010", "", "", WithRemoteProtocol())
 ```

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -78,8 +78,8 @@ func (cfg *connectionConfig) command() []string {
 	return c
 }
 
-// OpenWithParameters executes a nrjmx command using the given options.
-func OpenWithParameters(hostname, port, username, password string, opts ...Option) error {
+// Open executes a nrjmx command using the given options.
+func Open(hostname, port, username, password string, opts ...Option) error {
 	config := &connectionConfig{
 		hostname: hostname,
 		port:     port,

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -70,7 +69,7 @@ func (cfg *connectionConfig) command() []string {
 		c = append(c, "--username", cfg.username, "--password", cfg.password)
 	}
 	if cfg.remote {
-		c = append(c, "--remote", strconv.FormatBool(cfg.remote))
+		c = append(c, "--remote")
 	}
 	if cfg.isSSL() {
 		c = append(c, "--keyStore", cfg.keyStore, "--keyStorePassword", cfg.keyStorePassword, "--trustStore", cfg.trustStore, "--trustStorePassword", cfg.trustStorePassword)

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -78,36 +78,6 @@ func (cfg *connectionConfig) command() []string {
 	return c
 }
 
-// Open will start the nrjmx command with the provided connection parameters.
-// Deprecated use OpenWithParameters instead.
-func Open(hostname, port, username, password string) error {
-	config := &connectionConfig{
-		hostname: hostname,
-		port:     port,
-		username: username,
-		password: password,
-	}
-
-	return openConnection(config)
-}
-
-// OpenWithSSL will start the nrjmx command with the provided SSL connection parameters.
-// Deprecated use OpenWithParameters instead.
-func OpenWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string) error {
-	config := &connectionConfig{
-		hostname:           hostname,
-		port:               port,
-		username:           username,
-		password:           password,
-		keyStore:           keyStore,
-		keyStorePassword:   keyStorePassword,
-		trustStore:         trustStore,
-		trustStorePassword: trustStorePassword,
-	}
-
-	return openConnection(config)
-}
-
 // OpenWithParameters executes a nrjmx command using the given options.
 func OpenWithParameters(hostname, port, username, password string, opts ...Option) error {
 	config := &connectionConfig{

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -78,13 +78,13 @@ func TestOpenWithSSL_OnlyWorksWhenClosed(t *testing.T) {
 	assert.NoError(t, OpenWithSSL("", "", "", "", "", "", "", ""))
 }
 
-func TestOpenWithSSLRemote_OnlyWorksWhenClosed(t *testing.T) {
+func TestOpenWithParameters_OnlyWorksWhenClosed(t *testing.T) {
 	defer Close()
 
-	assert.NoError(t, OpenWithSSLRemote("", "", "", "", "", "", "", "", false))
-	assert.Error(t, OpenWithSSLRemote("", "", "", "", "", "", "", "", false))
+	assert.NoError(t, OpenWithParameters("", "", "", ""))
+	assert.Error(t, OpenWithParameters("", "", "", ""))
 	Close()
-	assert.NoError(t, OpenWithSSLRemote("", "", "", "", "", "", "", "", false))
+	assert.NoError(t, OpenWithParameters("", "", "", ""))
 }
 
 func TestQuery(t *testing.T) {

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -60,24 +60,6 @@ func TestMain(m *testing.M) {
 	}
 }
 
-func TestOpen_OnlyWorksWhenClosed(t *testing.T) {
-	defer Close()
-
-	assert.NoError(t, Open("", "", "", ""))
-	assert.Error(t, Open("", "", "", ""))
-	Close()
-	assert.NoError(t, Open("", "", "", ""))
-}
-
-func TestOpenWithSSL_OnlyWorksWhenClosed(t *testing.T) {
-	defer Close()
-
-	assert.NoError(t, OpenWithSSL("", "", "", "", "", "", "", ""))
-	assert.Error(t, OpenWithSSL("", "", "", "", "", "", "", ""))
-	Close()
-	assert.NoError(t, OpenWithSSL("", "", "", "", "", "", "", ""))
-}
-
 func TestOpenWithParameters_OnlyWorksWhenClosed(t *testing.T) {
 	defer Close()
 
@@ -169,7 +151,8 @@ func openWait(hostname, port, username, password string, attempts int) error {
 }
 
 func openWaitWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string, attempts int) error {
-	err := OpenWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword)
+	ssl := WithSSL(keyStore, keyStorePassword, trustStore, trustStorePassword)
+	err := OpenWithParameters(hostname, port, username, password, ssl)
 	if err == ErrJmxCmdRunning && attempts > 0 {
 		attempts--
 		time.Sleep(10 * time.Millisecond)

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -63,10 +63,10 @@ func TestMain(m *testing.M) {
 func TestOpenWithParameters_OnlyWorksWhenClosed(t *testing.T) {
 	defer Close()
 
-	assert.NoError(t, OpenWithParameters("", "", "", ""))
-	assert.Error(t, OpenWithParameters("", "", "", ""))
+	assert.NoError(t, Open("", "", "", ""))
+	assert.Error(t, Open("", "", "", ""))
 	Close()
-	assert.NoError(t, OpenWithParameters("", "", "", ""))
+	assert.NoError(t, Open("", "", "", ""))
 }
 
 func TestQuery(t *testing.T) {
@@ -152,7 +152,7 @@ func openWait(hostname, port, username, password string, attempts int) error {
 
 func openWaitWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string, attempts int) error {
 	ssl := WithSSL(keyStore, keyStorePassword, trustStore, trustStorePassword)
-	err := OpenWithParameters(hostname, port, username, password, ssl)
+	err := Open(hostname, port, username, password, ssl)
 	if err == ErrJmxCmdRunning && attempts > 0 {
 		attempts--
 		time.Sleep(10 * time.Millisecond)

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -78,6 +78,15 @@ func TestOpenWithSSL_OnlyWorksWhenClosed(t *testing.T) {
 	assert.NoError(t, OpenWithSSL("", "", "", "", "", "", "", ""))
 }
 
+func TestOpenWithSSLRemote_OnlyWorksWhenClosed(t *testing.T) {
+	defer Close()
+
+	assert.NoError(t, OpenWithSSLRemote("", "", "", "", "", "", "", "", false))
+	assert.Error(t, OpenWithSSLRemote("", "", "", "", "", "", "", "", false))
+	Close()
+	assert.NoError(t, OpenWithSSLRemote("", "", "", "", "", "", "", "", false))
+}
+
 func TestQuery(t *testing.T) {
 	for q, isErr := range query2IsErr {
 		assert.NoError(t, openWait("", "", "", "", openAttempts), "error on opening for query %s", q)


### PR DESCRIPTION
Added a remote boolean flag for the **NR_JMX_TOOL** for enabling  jmx client in EAP 6.

### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
