### PR TITLE
Add entity attributes

### DIFF
--- a/integration/entity.go
+++ b/integration/entity.go
@@ -128,6 +128,13 @@ func (e *Entity) SetInventoryItem(key string, field string, value interface{}) e
 	return e.Inventory.SetItem(key, field, value)
 }
 
+// AddAttributes adds attributes to every entity metric-set.
+func (e *Entity) AddAttributes(attributes ...metric.Attribute) {
+	for _, a := range attributes {
+		e.setCustomAttribute(a.Key, a.Value)
+	}
+}
+
 func (e *Entity) setCustomAttribute(key string, value string) {
 	attribute := metric.Attribute{key, value}
 	e.customAttributes = append(e.customAttributes, attribute)


### PR DESCRIPTION
#### Description of the changes

SDK feature proposal *Attaching attributes to entity*:

There are cases (integrations) where attributes should be added to all the metrics (actually metric-*sets*) of an entity.

Current SDK only allow adding them on a per metric-*set* basis (using `nameSpacingAttributes` https://github.com/newrelic/infra-integrations-sdk/blob/master/integration/entity.go#L98 ). So for every the metric-*set* you have to add them (see https://github.com/newrelic/nri-rabbitmq/blob/master/src/metrics/metrics.go#L59 )

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
