### PR TITLE
EntityKey + attributes: ReportingEntityKey & ReportingEndpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next Release
 
+### Added
+
+- Standardise the attributes used to store the data sources: reporting-entity & reporting-endpoint under new attributes:
+ `reportingEntityKey`, `reportingEndpoint`. See [doc](/docs/entity-definition.md#entity-reporting-data). 
+
 ### Changed
 
 - New JMX option for remote URL protocol connections.

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Attribute represents an attribute metric in key-value pair format.
+// Attribute represents a metric attribute key-value pair.
 type Attribute struct {
 	Key   string
 	Value string

--- a/docs/entity-definition.md
+++ b/docs/entity-definition.md
@@ -1,20 +1,64 @@
 # What is an entity?
 
-We use the vague term entity because we want to support hosts, pods, load balancers, DBs, etc. in a generic way. In the previous SDK versions (v1 & v2) the entity was local and just one, the host. In later versions the host reporting is called local entity, and it's optional to add metrics to it. You could just use remote entities to attach metrics. An entity can have its own inventory (configuration/state) and report any kind of metrics about itself. Although we may define a new entity for each monitored thing, we may want to relate/group some of them within a parent (local) entity (ie: host it's running on).
- 
-Given we wanted to offer support for remote entities,let’s start by defining what we mean by an entity. **Entity** is a general term and refers to is a specific thing we collect data about. We used this term generally because we want to monitor different services and will need to support different parts such as hosts, pods, load balancers, DBs, etc. In the previous SDK versions (v1 & v2) the entity was local and just one, the host. However, as the entity does not necessarily have to be a host, we have broadened our support to include remote entities.
- 
-## What do we mean by remote entity?
+We use the vague term entity because we want to support hosts, pods, load balancers, DBs, etc. in a generic way. 
 
-We have defined an entity is defined as anything we collect data about. Previously, the entity was the local machine. In the new version, the **local entity** is the the local host. This leaves us to define what we mean by **remote entities**.
+An entity can have its own inventory (configuration/state) and report any kind of metrics about itself. 
+
+**Entity** is a general term and refers to is a specific thing we collect data about. We used this term generally 
+because we want to monitor different services and will need to support different parts such as hosts, pods, load 
+balancers, DBs, etc. 
+
+
+## Local vs Remote entities
+
+In the previous SDK versions (v1 & v2) the entity was local and just one, the host. In later versions the host 
+reporting/forwarding data is called **local entity**, and it represent the host running the agent.
+
+Since SDK version v3 you can use a new entity for each monitored thing. These non-local entities are named 
+**remote entities**.
+
+A **remote entity** is something being monitored, but it is no longer attached to the host running the agent. It 
+groups a set of metrics or storing inventory.
+
+It's optional to add metrics to either the **local entity** or any **remote entities**.
+
+For example:
+
+> An engineer installs the infrastructure agent on *host1* and configures the out-of-the-box *mysql integration* to 
+> monitor a *MySQL server* running on *host2*. *Host1* would be a "local entity" and the *MySQL server* on *Host2* 
+> would be a “remote entity”.
+
+
+### Host disclaimer
+
+Historically New Relic infrastructure product has treated hosts as the only possible entities (see prior SDK versions 
+mentioned above).
+
+For this reason some UI components may display the text *Hosts* when referring to *Entities*.
+
+
+### Data sources
+
+Optionally we might want to know/store the sources of an entity data.
+
+We may want to differentiate:
+
+- The entity **producing** a remote entity data
+- The entity **reporting** a remote entity data 
+
+This gets relevance whenever the endpoint/entity reporting a remote-entity data is not the one producing it.
+
+Usually for clusterised services, for instance being "cluster" and "nodes" entities. Then to retrieve a cluster-entity 
+an **endpoint** or a node (**entity**) report data about this cluster-entity.
+
+> This might also apply to nodes reporting other nodes statues.
  
-So what do we mean by remote entities? A remote entity is an entity, as understood above, that 1) is not the local host where either the agent and integration live or 2) is not equivalent to a “host”. In this way, we offer support to monitor a whole host of things, forgive the bad pun, that we might not otherwise be able to, due to being able to get an agent on the host or the architecture itself requiring the concept of multiple “entities”.
- 
-> For Example:
->
-> An engineer installs the infrastructure agent on host1 and configures the out-of-the-box mysql integration to monitor a MySQL server running on host2. Host1 would be an entity as far as the Infrastructure entity is concerned and the MySQL servers on Host2 would be a “remote entity”.
->
-> An engineer installs the infrastructure agent on host1 and configures the out-of-the-box kubernetes integration and collects metrics and inventory about the whole cluster, replica sets, pods and nodes.
+In this case we may want to know which entity or endpoint is reporting a given entity data.
+
+The standard way to do it is using this *optional* attributes:
+
+- `reportingEntityKey`: entity reporting actual entity data.  
+- `reportingEndpoint`: endpoint reporting current entity data.
 
 
 ## Entity uniqueness

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -23,9 +23,6 @@ type Entity struct {
 	customAttributes []metric.Attribute
 }
 
-//IDAttributes used for the entity key uniqueness
-type IDAttributes []IDAttribute
-
 // EntityMetadata stores entity Metadata
 type EntityMetadata struct {
 	Name      string       `json:"name"`
@@ -77,18 +74,6 @@ func newEntity(
 	return &d, nil
 }
 
-func idAttributes(idAttrs ...IDAttribute) IDAttributes {
-	attrs := make(IDAttributes, len(idAttrs))
-	if len(attrs) == 0 {
-		return attrs
-	}
-	for i, attr := range idAttrs {
-		attrs[i] = attr
-	}
-
-	return attrs
-}
-
 // isLocalEntity returns true if entity is the default one (has no identifier: name & type)
 func (e *Entity) isLocalEntity() bool {
 	return e.Metadata == nil || e.Metadata.Name == ""
@@ -131,4 +116,9 @@ func (e *Entity) SetInventoryItem(key string, field string, value interface{}) e
 func (e *Entity) setCustomAttribute(key string, value string) {
 	attribute := metric.Attribute{key, value}
 	e.customAttributes = append(e.customAttributes, attribute)
+}
+
+// Key unique entity identifier within a New Relic customer account.
+func (e *Entity) Key() (EntityKey, error) {
+	return e.Metadata.Key()
 }

--- a/integration/entity_id.go
+++ b/integration/entity_id.go
@@ -1,0 +1,98 @@
+package integration
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// EmptyKey empty entity key.
+var EmptyKey = EntityKey("")
+
+// EntityKey unique identifier for an entity within a New Relic customer account.
+type EntityKey string
+
+//IDAttributes list of identifier attributes used to provide uniqueness for an entity key.
+type IDAttributes []IDAttribute
+
+// IDAttribute identifier attribute key-value pair.
+type IDAttribute struct {
+	Key   string
+	Value string
+}
+
+// NewIDAttribute creates new identifier attribute.
+func NewIDAttribute(key, value string) IDAttribute {
+	return IDAttribute{
+		Key:   key,
+		Value: value,
+	}
+}
+
+// String stringer stuff
+func (k EntityKey) String() string {
+	return string(k)
+}
+
+// Key generates the entity key based on the entity metadata.
+func (m *EntityMetadata) Key() (EntityKey, error) {
+	if len(m.Name) == 0 {
+		return EmptyKey, nil // Empty value means this agent's default entity identifier
+	}
+	if m.Namespace == "" {
+		//invalid entity: it has name, but not type.
+		return EmptyKey, fmt.Errorf("missing 'namespace' field for entity name '%v'", m.Name)
+	}
+
+	attrsStr := ""
+	sort.Sort(m.IDAttrs)
+	m.IDAttrs.removeEmptyAndDuplicates()
+	for _, attr := range m.IDAttrs {
+		attrsStr = fmt.Sprintf("%v:%v=%v", attrsStr, attr.Key, attr.Value)
+	}
+
+	return EntityKey(fmt.Sprintf("%v:%v%s", m.Namespace, m.Name, strings.ToLower(attrsStr))), nil
+}
+
+func idAttributes(idAttrs ...IDAttribute) IDAttributes {
+	attrs := make(IDAttributes, len(idAttrs))
+	if len(attrs) == 0 {
+		return attrs
+	}
+	for i, attr := range idAttrs {
+		attrs[i] = attr
+	}
+
+	return attrs
+}
+
+// Len is part of sort.Interface.
+func (a IDAttributes) Len() int {
+	return len(a)
+}
+
+// Swap is part of sort.Interface.
+func (a IDAttributes) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+// Less is part of sort.Interface.
+func (a IDAttributes) Less(i, j int) bool {
+	return a[i].Key < a[j].Key
+}
+
+func (a *IDAttributes) removeEmptyAndDuplicates() {
+
+	var uniques IDAttributes
+	var prev IDAttribute
+	for i, attr := range *a {
+		if prev.Key != attr.Key && attr.Key != "" {
+			uniques = append(uniques, attr)
+		} else if uniques.Len() >= 1 {
+			uniques[i-1].Value = attr.Value
+		}
+		prev = attr
+	}
+
+	*a = uniques
+}

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -167,3 +167,23 @@ func TestEntity_IsDefaultEntity(t *testing.T) {
 	assert.Empty(t, e.Metadata, "default entity should have no identifier")
 	assert.True(t, e.isLocalEntity())
 }
+
+func TestEntity_Key(t *testing.T) {
+	e, err := newEntity("entity", "ns", persist.NewInMemoryStore(), false)
+	assert.NoError(t, err)
+
+	k, err := e.Key()
+	assert.NoError(t, err)
+	assert.Equal(t, "ns:entity", k.String())
+}
+
+func TestEntity_Key_WithIDAttrs(t *testing.T) {
+	attr1 := NewIDAttribute("env", "prod")
+	attr2 := NewIDAttribute("srv", "auth")
+	e, err := newEntity("entity", "ns", persist.NewInMemoryStore(), false, attr1, attr2)
+	assert.NoError(t, err)
+
+	k, err := e.Key()
+	assert.NoError(t, err)
+	assert.Equal(t, "ns:entity:env=prod:srv=auth", k.String())
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -23,6 +23,12 @@ const (
 	CustomAttrService = "service_name"
 )
 
+// Standard attributes
+const (
+	AttrReportingEntity   = "reportingEntityKey"
+	AttrReportingEndpoint = "reportingEndpoint"
+)
+
 // NR infrastructure agent protocol version
 const (
 	protocolVersion = "3"
@@ -41,20 +47,6 @@ type Integration struct {
 	writer             io.Writer
 	logger             log.Logger
 	args               interface{}
-}
-
-// IDAttribute is a Key Value struct which is used to have uniqueness during the entity Key resolution.
-type IDAttribute struct {
-	Key   string
-	Value string
-}
-
-// NewIDAttribute creates new identifier attribute.
-func NewIDAttribute(key, value string) IDAttribute {
-	return IDAttribute{
-		Key:   key,
-		Value: value,
-	}
 }
 
 // New creates new integration with sane default values.
@@ -129,6 +121,28 @@ func (i *Integration) LocalEntity() *Entity {
 	i.Entities = append(i.Entities, e)
 
 	return e
+}
+
+// EntityReportedBy entity being reported from another entity that is not producing the actual entity data.
+func (i *Integration) EntityReportedBy(reportingEntity EntityKey, reportedEntityName, reportedEntityNamespace string, idAttributes ...IDAttribute) (e *Entity, err error) {
+	e, err = i.Entity(reportedEntityName, reportedEntityNamespace, idAttributes...)
+	if err != nil {
+		return
+	}
+
+	e.setCustomAttribute(AttrReportingEntity, reportingEntity.String())
+	return
+}
+
+// EntityReportedVia entity being reported from a known endpoint.
+func (i *Integration) EntityReportedVia(endpoint, reportedEntityName, reportedEntityNamespace string, idAttributes ...IDAttribute) (e *Entity, err error) {
+	e, err = i.Entity(reportedEntityName, reportedEntityNamespace, idAttributes...)
+	if err != nil {
+		return
+	}
+
+	e.setCustomAttribute(AttrReportingEndpoint, endpoint)
+	return
 }
 
 // Entity method creates or retrieves an already created entity.


### PR DESCRIPTION
#### Description of the changes

We may also want to differentiate:

- The host/entity **producing** a remote entity data
- The host/entity **reporting** a remote entity data 

This gets relevance whenever the host reporting remote entity data is not the one producing it.

Usually for clusterised services a host/node entity reports data about the cluster entity. In this case we may want 
to know which entity (host/node) is reporting this cluster-entity data.

To know which entity is reporting current entity data we introduce the `integration.EntityKey` type and new attributes for metrics `reportingEntityKey` and `ReportingEndpoint`.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
