### PR TITLE
Entity fetching uses identifier attributes

### DIFF
--- a/integration/entity.go
+++ b/integration/entity.go
@@ -30,6 +30,26 @@ type EntityMetadata struct {
 	IDAttrs   IDAttributes `json:"id_attributes"` // For entity Key uniqueness
 }
 
+// EqualsTo returns true when both metadata are equal.
+func (m *EntityMetadata) EqualsTo(b *EntityMetadata) bool {
+	// prevent checking on Key() for performance
+	if m.Name != b.Name || m.Namespace != b.Namespace {
+		return false
+	}
+
+	k1, err := m.Key()
+	if err != nil {
+		return false
+	}
+
+	k2, err := b.Key()
+	if err != nil {
+		return false
+	}
+
+	return k1.String() == k2.String()
+}
+
 // newLocalEntity creates unique default entity without identifier (name & type)
 func newLocalEntity(storer persist.Storer, addHostnameToMetadata bool) *Entity {
 	return &Entity{
@@ -77,6 +97,15 @@ func newEntity(
 // isLocalEntity returns true if entity is the default one (has no identifier: name & type)
 func (e *Entity) isLocalEntity() bool {
 	return e.Metadata == nil || e.Metadata.Name == ""
+}
+
+// SameAs return true when is same entity
+func (e *Entity) SameAs(b *Entity) bool {
+	if e.Metadata == nil || b.Metadata == nil {
+		return false
+	}
+
+	return e.Metadata.EqualsTo(b.Metadata)
 }
 
 // NewMetricSet returns a new instance of Set with its sample attached to the integration.

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -210,3 +210,18 @@ func TestEntity_Key_WithIDAttrs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "ns:entity:env=prod:srv=auth", k.String())
 }
+
+func TestEntity_SameAs(t *testing.T) {
+	attr := NewIDAttribute("env", "prod")
+	e1, err := newEntity("entity", "ns", persist.NewInMemoryStore(), false, attr)
+	assert.NoError(t, err)
+
+	e2, err := newEntity("entity", "ns", persist.NewInMemoryStore(), false, attr)
+	assert.NoError(t, err)
+
+	e3, err := newEntity("entity", "ns", persist.NewInMemoryStore(), false)
+	assert.NoError(t, err)
+
+	assert.True(t, e1.SameAs(e2))
+	assert.False(t, e1.SameAs(e3))
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -150,16 +150,15 @@ func (i *Integration) Entity(name, namespace string, idAttributes ...IDAttribute
 	i.locker.Lock()
 	defer i.locker.Unlock()
 
-	// we should change this to map for performance
-	for _, e = range i.Entities {
-		if e.Metadata != nil && e.Metadata.Name == name && e.Metadata.Namespace == namespace {
-			return e, nil
-		}
-	}
-
 	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta, idAttributes...)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, eIt := range i.Entities {
+		if e.SameAs(eIt) {
+			return eIt, nil
+		}
 	}
 
 	defaultArgs := args.GetDefaultArgs(i.args)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -81,6 +81,22 @@ func TestIntegration_Entity(t *testing.T) {
 	assert.Equal(t, e1, e3, "Same namespace & name create/retrieve same entity")
 }
 
+func TestIntegration_Entity_WithIDAttrs(t *testing.T) {
+	i := newTestIntegration(t)
+
+	idAttr := NewIDAttribute("k", "v")
+
+	e1, err := i.Entity("name", "ns", idAttr)
+	assert.NoError(t, err)
+	e2, err := i.Entity("name", "ns")
+	assert.NoError(t, err)
+	e3, err := i.Entity("name", "ns", idAttr)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, e1, e2, "Different id-attributes create different entities")
+	assert.Equal(t, e1, e3, "Same namespace, name and id-attributes create/retrieve same entity")
+}
+
 func TestIntegration_EntityReportedBy(t *testing.T) {
 	i := newTestIntegration(t)
 


### PR DESCRIPTION
#### Description of the changes

[Identifier attributes](/blob/master/docs/entity-definition.md#identifier-attributes) are a coupled to the entity uniqueness. So different id-attrs should fetch/create different entities.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
