### PR TITLE
Add uriPath option to support ForgeRock OpenDJ

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -43,6 +43,7 @@ const (
 type connectionConfig struct {
 	hostname           string
 	port               string
+	uriPath            string
 	username           string
 	password           string
 	keyStore           string
@@ -65,6 +66,9 @@ func (cfg *connectionConfig) command() []string {
 	}
 
 	c = append(c, "--hostname", cfg.hostname, "--port", cfg.port)
+	if cfg.uriPath != "" {
+		c = append(c, "--uriPath", cfg.uriPath)
+	}
 	if cfg.username != "" && cfg.password != "" {
 		c = append(c, "--username", cfg.username, "--password", cfg.password)
 	}
@@ -96,6 +100,13 @@ func Open(hostname, port, username, password string, opts ...Option) error {
 
 // Option sets an option on integration level.
 type Option func(config *connectionConfig)
+
+//WithURIPath for specifying non standard(jmxrmi) path on jmx service uri
+func WithURIPath(uriPath string) Option {
+	return func(config *connectionConfig) {
+		config.uriPath = uriPath
+	}
+}
 
 // WithSSL for SSL connection configuration.
 func WithSSL(keyStore, keyStorePassword, trustStore, trustStorePassword string) Option {

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -44,7 +44,7 @@ type connectionConfig struct {
 
 	hostname              string
 	port                  string
-        uriPath               string
+	uriPath               string
 	username              string
 	password              string
 	keyStore              string

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -44,7 +44,7 @@ type connectionConfig struct {
 
 	hostname              string
 	port                  string
-  uriPath               string
+        uriPath               string
 	username              string
 	password              string
 	keyStore              string

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -41,7 +41,6 @@ const (
 
 // connectionConfig is the configuration for the nrjmx command.
 type connectionConfig struct {
-
 	hostname              string
 	port                  string
 	uriPath               string


### PR DESCRIPTION
#### Description of the changes

Add uriPath command line option to support applications that use non-standard JMX service urls such as ForgeRock OpenDJ.

OpenDJ uses a JMX service uri like: service:jmx:rmi:///jndi/rmi://localhost:1689/org.opends.server.protocols.jmx.client-unknown

This pull request depends on enhancements to nrjmx in this pull request: https://github.com/newrelic/nrjmx/pull/19

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [X ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
