### PR TITLE
JMX Remote Domain and Standalone JBoss modes

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -41,15 +41,16 @@ const (
 
 // connectionConfig is the configuration for the nrjmx command.
 type connectionConfig struct {
-	hostname           string
-	port               string
-	username           string
-	password           string
-	keyStore           string
-	keyStorePassword   string
-	trustStore         string
-	trustStorePassword string
-	remote             bool
+	hostname              string
+	port                  string
+	username              string
+	password              string
+	keyStore              string
+	keyStorePassword      string
+	trustStore            string
+	trustStorePassword    string
+	remote                bool
+	remoteJBossStandalone bool
 }
 
 func (cfg *connectionConfig) isSSL() bool {
@@ -70,6 +71,9 @@ func (cfg *connectionConfig) command() []string {
 	}
 	if cfg.remote {
 		c = append(c, "--remote")
+	}
+	if cfg.remoteJBossStandalone {
+		c = append(c, "--remoteJBossStandalone")
 	}
 	if cfg.isSSL() {
 		c = append(c, "--keyStore", cfg.keyStore, "--keyStorePassword", cfg.keyStorePassword, "--trustStore", cfg.trustStore, "--trustStorePassword", cfg.trustStorePassword)
@@ -107,10 +111,18 @@ func WithSSL(keyStore, keyStorePassword, trustStore, trustStorePassword string) 
 	}
 }
 
-// WithRemoteProtocol uses the remote JMX protocol URL.
+// WithRemoteProtocol uses the remote JMX protocol URL (by default on JBoss Domain-mode).
 func WithRemoteProtocol() Option {
 	return func(config *connectionConfig) {
 		config.remote = true
+	}
+}
+
+// WithRemoteStandAloneJBoss uses the remote JMX protocol URL on JBoss Standalone-mode.
+func WithRemoteStandAloneJBoss() Option {
+	return func(config *connectionConfig) {
+		config.remote = true
+		config.remoteJBossStandalone = true
 	}
 }
 


### PR DESCRIPTION
#### Description of the changes

Sets JMX remote mode ready for JBoss Domain-mode and adds support to enable JBoss Standalone-mode.

Official doc for remoting v3 is not available, see:
 - https://developer.jboss.org/thread/196619
 - http://jbossremoting.jboss.org/documentation/v3.html
Some doc on URIS at:
 - https://github.com/jboss-remoting/jboss-remoting/blob/master/src/main/java/org/jboss/remoting3/EndpointImpl.java#L292-L304
 - https://stackoverflow.com/questions/42970921/what-is-http-remoting-protocol
- http://www.mastertheboss.com/jboss-server/jboss-monitoring/using-jconsole-to-monitor-a-remote-wildfly-server.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
