### PR TITLE
[Waiting for agent release] Add support for event attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## NEXT
+## 3.4.0
 
 ### Added
 
-[//]: # (TODO: FIX AGENT VERSION)
+- Support for event attributes. Supported since infra agent version 1.5.31.
 
-- Support for event attributes. Supported since infra agent version X.X.X
+## 3.3.1
+
+### Added
+
+- JMX support for custom URI paths (this enables support for integrations like ForgeRock OpenDJ)
+
+## 3.3.0
+
+### Added
+
+- JMX JBoss remote support for Domain-mode as default and Standalone-mode optionally.
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## NEXT
+
+### Added
+
+- Support for event attributes.
+
 ## 3.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Support for event attributes.
+[//]: # (TODO: FIX AGENT VERSION)
+
+- Support for event attributes. Supported since infra agent version X.X.X
 
 ## 3.2.0
 

--- a/data/event/event.go
+++ b/data/event/event.go
@@ -6,10 +6,22 @@ const (
 )
 
 // Event is the data type to represent arbitrary, one-off messages for key
-// activities on a system.
+// activities on a system. Ex:
+//
+// Event{
+//   Category: "gear",
+//   Summary:  "gear has been changed",
+//   Attributes: map[string]interface{}{
+//     "oldGear":      3,
+//     "newGear":      4,
+//     "transmission": "manual",
+//   },
+// }
 type Event struct {
-	Summary    string                 `json:"summary"`
-	Category   string                 `json:"category,omitempty"`
+	Summary  string `json:"summary"`
+	Category string `json:"category,omitempty"`
+	// Attributes are optional, they represent additional information that
+	// can be attached to an event.
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 

--- a/data/event/event.go
+++ b/data/event/event.go
@@ -8,8 +8,9 @@ const (
 // Event is the data type to represent arbitrary, one-off messages for key
 // activities on a system.
 type Event struct {
-	Summary  string `json:"summary"`
-	Category string `json:"category,omitempty"`
+	Summary    string                 `json:"summary"`
+	Category   string                 `json:"category,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
 // New creates a new event.
@@ -23,4 +24,11 @@ func New(summary, category string) *Event {
 // NewNotification creates a new notification event.
 func NewNotification(summary string) *Event {
 	return New(summary, NotificationEventCategory)
+}
+
+// NewWithAttributes creates a new event with the given attributes
+func NewWithAttributes(summary, category string, attributes map[string]interface{}) *Event {
+	e := New(summary, category)
+	e.Attributes = attributes
+	return e
 }

--- a/data/event/event_test.go
+++ b/data/event/event_test.go
@@ -17,3 +17,15 @@ func TestNewNotification(t *testing.T) {
 	n := NewNotification("summary")
 	assert.Equal(t, n.Summary, "summary")
 }
+
+func TestNewAttributes(t *testing.T) {
+	e := NewWithAttributes(
+		"summary",
+		"category",
+		map[string]interface{}{"attrKey": "attrVal"},
+	)
+
+	assert.Equal(t, e.Summary, "summary")
+	assert.Equal(t, e.Category, "category")
+	assert.Equal(t, e.Attributes["attrKey"], "attrVal")
+}

--- a/docs/v2tov3.md
+++ b/docs/v2tov3.md
@@ -108,7 +108,12 @@ The `v2` JSON schema also adds the following fields for each entry in the `metri
       "events": [
         {
           "category": "gear",
-          "summary": "gear has been changed"
+          "summary": "gear has been changed",
+          "attributes": {
+            "oldGear": 3,
+            "newGear": 4,
+            "transmission": "manual"
+          }
         }
       ]
     }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -313,7 +313,11 @@ func TestIntegration_Publish(t *testing.T) {
 				  "events": [
 					{
 					  "summary": "evnt1sum",
-					  "category": "evnt1cat"
+					  "category": "evnt1cat",
+						"attributes": {
+							"attr1": "attr1Val",
+							"attr2": 42
+						}
 					},
 					{
 					  "summary": "evnt2sum",
@@ -361,7 +365,14 @@ func TestIntegration_Publish(t *testing.T) {
 	assert.NoError(t, ms.SetMetric("metricTwo", "test", metric.ATTRIBUTE))
 	assert.NoError(t, ms.SetMetric("metricBool", true, metric.GAUGE))
 
-	assert.NoError(t, e.AddEvent(event.New("evnt1sum", "evnt1cat")))
+	assert.NoError(t, e.AddEvent(event.NewWithAttributes(
+		"evnt1sum",
+		"evnt1cat",
+		map[string]interface{}{
+			"attr1": "attr1Val",
+			"attr2": 42,
+		},
+	)))
 	assert.NoError(t, e.AddEvent(event.New("evnt2sum", "evnt2cat")))
 
 	e2, err := i.Entity("EntityTwo", "test")


### PR DESCRIPTION
#### Description of the changes

Adds support for event attributes, currently events only support two fields `summary` and `category`, this PR allows us to specify a map of key value attributes for the event.

PENDING:

- [ ] Add agent version supporting the feature

#### PR Review Checklist
### Author

- [ x] add a risk label after carefully considering the "blast radius" of your changes
- [ x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
