### PR TITLE
Enable custom attributes for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - JMX no-auth connection
 - JMX constructor option to provice custom nrjmx tool executable
 - JMX full connection URL
+- Allow events that contain attributes to be decorated by the entity 
+  customAttributes.
 
 ### Changed
 

--- a/data/attribute/attribute.go
+++ b/data/attribute/attribute.go
@@ -1,4 +1,4 @@
-package attributes
+package attribute
 
 import "fmt"
 

--- a/data/attributes/attributes.go
+++ b/data/attributes/attributes.go
@@ -1,0 +1,46 @@
+package attributes
+
+import "fmt"
+
+const (
+	// nsAttributeSeparator is the metric attribute key-value separator applied to generate the metric ns.
+	nsAttributeSeparator = "=="
+)
+
+// Attribute represents a metric attribute key-value pair.
+type Attribute struct {
+	Key   string
+	Value string
+}
+
+// Attributes list of attributes
+type Attributes []Attribute
+
+// Required for Go < v.18, as these do not include sort.Slice
+
+// Len ...
+func (a Attributes) Len() int { return len(a) }
+
+// Swap ...
+func (a Attributes) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// Less ...
+func (a Attributes) Less(i, j int) bool {
+	if a[i].Key == a[j].Key {
+		return a[i].Value < a[j].Value
+	}
+	return a[i].Key < a[j].Key
+}
+
+// Namespace generates the string value of an attribute used to namespace a metric.
+func (a *Attribute) Namespace() string {
+	return fmt.Sprintf("%s%s%s", a.Key, nsAttributeSeparator, a.Value)
+}
+
+// Attr creates an attribute aimed to namespace a metric-set.
+func Attr(key string, value string) Attribute {
+	return Attribute{
+		Key:   key,
+		Value: value,
+	}
+}

--- a/data/event/event.go
+++ b/data/event/event.go
@@ -1,5 +1,7 @@
 package event
 
+import "github.com/newrelic/infra-integrations-sdk/data/attributes"
+
 const (
 	// NotificationEventCategory category for notification events.
 	NotificationEventCategory = "notifications"
@@ -43,4 +45,18 @@ func NewWithAttributes(summary, category string, attributes map[string]interface
 	e := New(summary, category)
 	e.Attributes = attributes
 	return e
+}
+
+func (e *Event) setAttribute(key string, val interface{}) {
+	e.Attributes[key] = val
+}
+
+// AddCustomAttributes add customAttributes to MetricSet
+func AddCustomAttributes(e *Event, customAttributes []attributes.Attribute) {
+	if e.Attributes == nil {
+		return
+	}
+	for _, attr := range customAttributes {
+		e.setAttribute(attr.Key, attr.Value)
+	}
 }

--- a/data/event/event.go
+++ b/data/event/event.go
@@ -1,6 +1,6 @@
 package event
 
-import "github.com/newrelic/infra-integrations-sdk/data/attributes"
+import "github.com/newrelic/infra-integrations-sdk/data/attribute"
 
 const (
 	// NotificationEventCategory category for notification events.
@@ -53,7 +53,7 @@ func (e *Event) setAttribute(key string, val interface{}) {
 }
 
 // AddCustomAttributes add customAttributes to the Event
-func AddCustomAttributes(e *Event, customAttributes []attributes.Attribute) {
+func AddCustomAttributes(e *Event, customAttributes []attribute.Attribute) {
 	for _, attr := range customAttributes {
 		e.setAttribute(attr.Key, attr.Value)
 	}

--- a/data/event/event.go
+++ b/data/event/event.go
@@ -30,8 +30,9 @@ type Event struct {
 // New creates a new event.
 func New(summary, category string) *Event {
 	return &Event{
-		Summary:  summary,
-		Category: category,
+		Summary:    summary,
+		Category:   category,
+		Attributes: make(map[string]interface{}),
 	}
 }
 
@@ -51,11 +52,8 @@ func (e *Event) setAttribute(key string, val interface{}) {
 	e.Attributes[key] = val
 }
 
-// AddCustomAttributes add customAttributes to MetricSet
+// AddCustomAttributes add customAttributes to the Event
 func AddCustomAttributes(e *Event, customAttributes []attributes.Attribute) {
-	if e.Attributes == nil {
-		return
-	}
 	for _, attr := range customAttributes {
 		e.setAttribute(attr.Key, attr.Value)
 	}

--- a/data/event/event_test.go
+++ b/data/event/event_test.go
@@ -3,6 +3,7 @@ package event
 import (
 	"testing"
 
+	"github.com/newrelic/infra-integrations-sdk/data/attributes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +19,7 @@ func TestNewNotification(t *testing.T) {
 	assert.Equal(t, n.Summary, "summary")
 }
 
-func TestNewAttributes(t *testing.T) {
+func TestNewEventsWithAttributes(t *testing.T) {
 	e := NewWithAttributes(
 		"summary",
 		"category",
@@ -28,4 +29,20 @@ func TestNewAttributes(t *testing.T) {
 	assert.Equal(t, e.Summary, "summary")
 	assert.Equal(t, e.Category, "category")
 	assert.Equal(t, e.Attributes["attrKey"], "attrVal")
+}
+
+func TestEventsAddCustomAttributes(t *testing.T) {
+	e := &Event{
+		Summary:    "summary",
+		Category:   "category",
+		Attributes: map[string]interface{}{"attrKey": "attrVal"},
+	}
+
+	a := attributes.Attributes{attributes.Attr("clusterName", "my-cluster")}
+
+	AddCustomAttributes(e, a)
+
+	assert.Equal(t, e.Summary, "summary")
+	assert.Equal(t, e.Category, "category")
+	assert.Equal(t, e.Attributes, map[string]interface{}{"attrKey": "attrVal", "clusterName": "my-cluster"})
 }

--- a/data/event/event_test.go
+++ b/data/event/event_test.go
@@ -3,7 +3,7 @@ package event
 import (
 	"testing"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +38,7 @@ func TestEventsAddCustomAttributes(t *testing.T) {
 		Attributes: map[string]interface{}{"attrKey": "attrVal"},
 	}
 
-	a := attributes.Attributes{attributes.Attr("clusterName", "my-cluster")}
+	a := attribute.Attributes{attribute.Attr("clusterName", "my-cluster")}
 
 	AddCustomAttributes(e, a)
 

--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/pkg/errors"
 )
@@ -30,12 +30,12 @@ var (
 type Set struct {
 	storer       persist.Storer
 	Metrics      map[string]interface{}
-	nsAttributes []attributes.Attribute
+	nsAttributes []attribute.Attribute
 }
 
 // NewSet creates new metrics set, optionally related to a list of attributes. These attributes makes the metric-set unique.
 // If related attributes are used, then new attributes are added.
-func NewSet(eventType string, storer persist.Storer, attributes ...attributes.Attribute) (s *Set) {
+func NewSet(eventType string, storer persist.Storer, attributes ...attribute.Attribute) (s *Set) {
 	s = &Set{
 		Metrics:      make(map[string]interface{}),
 		storer:       storer,
@@ -52,7 +52,7 @@ func NewSet(eventType string, storer persist.Storer, attributes ...attributes.At
 }
 
 // AddCustomAttributes add customAttributes to MetricSet
-func AddCustomAttributes(metricSet *Set, customAttributes []attributes.Attribute) {
+func AddCustomAttributes(metricSet *Set, customAttributes []attribute.Attribute) {
 	for _, attr := range customAttributes {
 		metricSet.setSetAttribute(attr.Key, attr.Value)
 	}
@@ -168,7 +168,7 @@ func (ms *Set) namespace(metricName string) string {
 	separator := ""
 
 	attrs := ms.nsAttributes
-	sort.Sort(attributes.Attributes(attrs))
+	sort.Sort(attribute.Attributes(attrs))
 
 	for _, attr := range attrs {
 		ns = fmt.Sprintf("%s%s%s", ns, separator, attr.Namespace())

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +62,7 @@ func TestSet_SetMetricCachesRateAndDeltas(t *testing.T) {
 	for _, sourceType := range []SourceType{DELTA, RATE, PRATE, PDELTA} {
 		persist.SetNow(growingTime)
 
-		ms := NewSet("some-event-type", storer, attributes.Attr("k", "v"))
+		ms := NewSet("some-event-type", storer, attribute.Attr("k", "v"))
 
 		for _, tt := range rateAndDeltaTests {
 			// user should not store different types under the same key
@@ -105,7 +105,7 @@ func TestSet_SetMetricsRatesAndDeltas(t *testing.T) {
 
 			persist.SetNow(growingTime)
 
-			ms := NewSet("some-event-type", persist.NewInMemoryStore(), attributes.Attr("k", "v"))
+			ms := NewSet("some-event-type", persist.NewInMemoryStore(), attribute.Attr("k", "v"))
 
 			assert.NoError(t, ms.SetMetric("d", tc.firstValue, tc.sourceType))
 			assert.NoError(t, ms.SetMetric("d", tc.secondValue, tc.sourceType))
@@ -121,7 +121,7 @@ func TestSet_SetMetricPositivesThrowsOnNegativeValues(t *testing.T) {
 			ms := NewSet(
 				"some-event-type",
 				persist.NewInMemoryStore(),
-				attributes.Attr("k", "v"),
+				attribute.Attr("k", "v"),
 			)
 			assert.NoError(t, ms.SetMetric("d", 5, sourceType))
 			assert.Error(
@@ -165,7 +165,7 @@ func TestSet_SetMetric_IncorrectMetricType(t *testing.T) {
 }
 
 func TestSet_MarshalJSON(t *testing.T) {
-	ms := NewSet("some-event-type", persist.NewInMemoryStore(), attributes.Attr("k", "v"))
+	ms := NewSet("some-event-type", persist.NewInMemoryStore(), attribute.Attr("k", "v"))
 
 	ms.SetMetric("foo", 1, RATE)
 	ms.SetMetric("bar", 1, DELTA)
@@ -182,7 +182,7 @@ func TestSet_MarshalJSON(t *testing.T) {
 }
 
 func TestSet_UnmarshalJSON(t *testing.T) {
-	ms := NewSet("some-event-type", persist.NewInMemoryStore(), attributes.Attr("k", "v"))
+	ms := NewSet("some-event-type", persist.NewInMemoryStore(), attribute.Attr("k", "v"))
 
 	err := ms.UnmarshalJSON([]byte(`{"foo":0,"bar":1.5,"quux":"bar"}`))
 
@@ -200,7 +200,7 @@ func TestNewSet_FileStore_StoresBetweenRuns(t *testing.T) {
 	s, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	set1 := NewSet("type", s, attributes.Attr("k", "v"))
+	set1 := NewSet("type", s, attribute.Attr("k", "v"))
 
 	assert.NoError(t, set1.SetMetric("foo", 1, DELTA))
 
@@ -209,7 +209,7 @@ func TestNewSet_FileStore_StoresBetweenRuns(t *testing.T) {
 	s2, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	set2 := NewSet("type", s2, attributes.Attr("k", "v"))
+	set2 := NewSet("type", s2, attribute.Attr("k", "v"))
 
 	assert.NoError(t, set2.SetMetric("foo", 3, DELTA))
 
@@ -228,8 +228,8 @@ func TestNewSet_Attr_AddsAttributes(t *testing.T) {
 	set := NewSet(
 		"type",
 		storeWrite,
-		attributes.Attr("pod", "pod-a"),
-		attributes.Attr("node", "node-a"),
+		attribute.Attr("pod", "pod-a"),
+		attribute.Attr("node", "node-a"),
 	)
 
 	assert.Equal(t, "pod-a", set.Metrics["pod"])
@@ -245,9 +245,9 @@ func TestNewSet_Attr_SolvesCacheCollision(t *testing.T) {
 	storeWrite, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	ms1 := NewSet("type", storeWrite, attributes.Attr("pod", "pod-a"))
-	ms2 := NewSet("type", storeWrite, attributes.Attr("pod", "pod-a"))
-	ms3 := NewSet("type", storeWrite, attributes.Attr("pod", "pod-b"))
+	ms1 := NewSet("type", storeWrite, attribute.Attr("pod", "pod-a"))
+	ms2 := NewSet("type", storeWrite, attribute.Attr("pod", "pod-a"))
+	ms3 := NewSet("type", storeWrite, attribute.Attr("pod", "pod-b"))
 
 	assert.NoError(t, ms1.SetMetric("field", 1, DELTA))
 	assert.NoError(t, ms2.SetMetric("field", 2, DELTA))
@@ -259,7 +259,7 @@ func TestNewSet_Attr_SolvesCacheCollision(t *testing.T) {
 	storeRead, err := persist.NewFileStore(storeFile, log.Discard, 1*time.Hour)
 	assert.NoError(t, err)
 
-	msRead := NewSet("type", storeRead, attributes.Attr("pod", "pod-a"))
+	msRead := NewSet("type", storeRead, attribute.Attr("pod", "pod-a"))
 
 	// write is required to make data available for read
 	assert.NoError(t, msRead.SetMetric("field", 10, DELTA))
@@ -268,7 +268,7 @@ func TestNewSet_Attr_SolvesCacheCollision(t *testing.T) {
 }
 
 func TestSet_namespace(t *testing.T) {
-	s := NewSet("type", persist.NewInMemoryStore(), attributes.Attr("k", "v"))
+	s := NewSet("type", persist.NewInMemoryStore(), attribute.Attr("k", "v"))
 
 	assert.Equal(t, fmt.Sprintf("k==v::foo"), s.namespace("foo"))
 
@@ -276,8 +276,8 @@ func TestSet_namespace(t *testing.T) {
 	s = NewSet(
 		"type",
 		persist.NewInMemoryStore(),
-		attributes.Attr("k1", "v1"),
-		attributes.Attr("k2", "v2"),
+		attribute.Attr("k1", "v1"),
+		attribute.Attr("k2", "v2"),
 	)
 
 	assert.Equal(t, fmt.Sprintf("k1==v1::k2==v2::foo"), s.namespace("foo"))
@@ -286,8 +286,8 @@ func TestSet_namespace(t *testing.T) {
 	s = NewSet(
 		"type",
 		persist.NewInMemoryStore(),
-		attributes.Attr("k2", "v2"),
-		attributes.Attr("k1", "v1"),
+		attribute.Attr("k2", "v2"),
+		attribute.Attr("k1", "v1"),
 	)
 
 	assert.Equal(t, fmt.Sprintf("k1==v1::k2==v2::foo"), s.namespace("foo"))

--- a/data/metric/set_marshal_test.go
+++ b/data/metric/set_marshal_test.go
@@ -3,7 +3,7 @@ package metric
 import (
 	"testing"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/stretchr/testify/assert"
 )
@@ -133,7 +133,7 @@ func TestSet_MarshalMetricsMissingOrInvalidTags(t *testing.T) {
 }
 
 func newTestSet() *Set {
-	return NewSet("some-event-type", persist.NewInMemoryStore(), attributes.Attr("k", "v"))
+	return NewSet("some-event-type", persist.NewInMemoryStore(), attribute.Attr("k", "v"))
 }
 
 func assertEqualsMetrics(t *testing.T, expected map[string]interface{}, got map[string]interface{}) {

--- a/data/metric/set_marshal_test.go
+++ b/data/metric/set_marshal_test.go
@@ -3,6 +3,7 @@ package metric
 import (
 	"testing"
 
+	"github.com/newrelic/infra-integrations-sdk/data/attributes"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/stretchr/testify/assert"
 )
@@ -132,7 +133,7 @@ func TestSet_MarshalMetricsMissingOrInvalidTags(t *testing.T) {
 }
 
 func newTestSet() *Set {
-	return NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v"))
+	return NewSet("some-event-type", persist.NewInMemoryStore(), attributes.Attr("k", "v"))
 }
 
 func assertEqualsMetrics(t *testing.T, expected map[string]interface{}, got map[string]interface{}) {

--- a/docs/entity-definition.md
+++ b/docs/entity-definition.md
@@ -1,37 +1,37 @@
 # What is an entity?
 
-We use the vague term entity because we want to support hosts, pods, load balancers, DBs, etc. in a generic way. 
+We use the vague term entity because we want to support hosts, pods, load balancers, DBs, etc. in a generic way.
 
-An entity can have its own inventory (configuration/state) and report any kind of metrics about itself. 
+An entity can have its own inventory (configuration/state) and report any kind of metrics about itself.
 
-**Entity** is a general term and refers to is a specific thing we collect data about. We used this term generally 
-because we want to monitor different services and will need to support different parts such as hosts, pods, load 
-balancers, DBs, etc. 
+**Entity** is a general term and refers to is a specific thing we collect data about. We used this term generally
+because we want to monitor different services and will need to support different parts such as hosts, pods, load
+balancers, DBs, etc.
 
 
 ## Local vs Remote entities
 
-In the previous SDK versions (v1 & v2) the entity was local and just one, the host. In later versions the host 
+In the previous SDK versions (v1 & v2) the entity was local and just one, the host. In later versions the host
 reporting/forwarding data is called **local entity**, and it represent the host running the agent.
 
-Since SDK version v3 you can use a new entity for each monitored thing. These non-local entities are named 
+Since SDK version v3 you can use a new entity for each monitored thing. These non-local entities are named
 **remote entities**.
 
-A **remote entity** is something being monitored, but it is no longer attached to the host running the agent. It 
+A **remote entity** is something being monitored, but it is no longer attached to the host running the agent. It
 groups a set of metrics or storing inventory.
 
 It's optional to add metrics to either the **local entity** or any **remote entities**.
 
 For example:
 
-> An engineer installs the infrastructure agent on *host1* and configures the out-of-the-box *mysql integration* to 
-> monitor a *MySQL server* running on *host2*. *Host1* would be a "local entity" and the *MySQL server* on *Host2* 
+> An engineer installs the infrastructure agent on *host1* and configures the out-of-the-box *mysql integration* to
+> monitor a *MySQL server* running on *host2*. *Host1* would be a "local entity" and the *MySQL server* on *Host2*
 > would be a “remote entity”.
 
 
 ### Host disclaimer
 
-Historically New Relic infrastructure product has treated hosts as the only possible entities (see prior SDK versions 
+Historically New Relic infrastructure product has treated hosts as the only possible entities (see prior SDK versions
 mentioned above).
 
 For this reason some UI components may display the text *Hosts* when referring to *Entities*.
@@ -44,20 +44,20 @@ Optionally we might want to know/store the sources of an entity data.
 We may want to differentiate:
 
 - The entity **producing** a remote entity data
-- The entity **reporting** a remote entity data 
+- The entity **reporting** a remote entity data
 
 This gets relevance whenever the endpoint/entity reporting a remote-entity data is not the one producing it.
 
-Usually for clusterised services, for instance being "cluster" and "nodes" entities. Then to retrieve a cluster-entity 
+Usually for clusterised services, for instance being "cluster" and "nodes" entities. Then to retrieve a cluster-entity
 an **endpoint** or a node (**entity**) report data about this cluster-entity.
 
 > This might also apply to nodes reporting other nodes statues.
- 
+
 In this case we may want to know which entity or endpoint is reporting a given entity data.
 
 The standard way to do it is using this *optional* attributes:
 
-- `reportingEntityKey`: entity reporting actual entity data.  
+- `reportingEntityKey`: entity reporting actual entity data.
 - `reportingEndpoint`: endpoint reporting current entity data.
 
 
@@ -67,7 +67,7 @@ Entity uniqueness is provided by its **key**.
 
 An entity `key` is formed by its `namespace` (or *type*) and `name`. These fields are concatenated with `:` separator.
 
-> For instance: `integration.Entity("name", "ns")` would create an entity with a `key` value `ns:name`.   
+> For instance: `integration.Entity("name", "ns")` would create an entity with a `key` value `ns:name`.
 
 Entities are attached to a user account. Each integration is responsible for providing uniqueness for its entities.
 
@@ -98,7 +98,7 @@ Names could be composed of several fields, in this case we call these **identifi
 
 #### Identifier attributes
 
-Attributes that provide uniqueness to an entity.  
+Attributes that provide uniqueness to an entity.
 
 > Eg: If your endpoint gather several environments, then the endpoint string is not enough to identify a service if
 > you want to attach different data to each environment.
@@ -135,24 +135,26 @@ When you provide identifier-attributes:
 
 - It automatically attach all the attributes to the entity `key` as defined above.
 - It decorates all of the attached entity metrics with these attributes.
-  * So these metrics could be easily filtered in the UI or New Relic Insights. 
+  * So these metrics could be easily filtered in the UI or New Relic Insights.
 
 
 ## Metadata decoration
 
-Since [agent v1.0.1052](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-101052) entity metrics could be decorated with metadata.
+Since [agent v1.0.1052](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-101052)
+entity metrics and events can be decorated with metadata.
 
-At the moment integrations can only decorate their entities metrics with `hostname`, `clusterName` and `serviceName`.
-These are all optional decoration values provided via [args](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/toolset/args.md)
+Decoration by `hostname`, `clusterName` or `serviceName` can be set via
+[args](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/toolset/args.md).
 
+To decorate with custom provided metadata, the `metadata` flag should be enable
+via [args](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/toolset/args.md).
+If this flag is enabled all samples will be decorated with provided key-value
+pairs.
 
-### Custom provided metadata
+At the moment custom metadata can only be provided via environment variables.
+These should be prefixed with `NRI_{INTEGRATION_NAME}_`, were
+`{INTEGRATION_NAME}` is the name given to the
+[`Integration`](https://github.com/newrelic/infra-integrations-sdk/blob/master/integration/integration.go#L39).
 
-Any integration can be decorated by enabling `metadata` flag on [args](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/toolset/args.md) package.
-
-If this flag is enabled all samples will be decorated with provided key-value pairs.
-
-At the moment metadata could only be provided via environment variables. These should be prefixed with `NRI_` and value
-will be provided after an equal sign `=` separator. 
-
-Ie: `NRI_{INTEGRATION_NAME}_FOO=BAR` will decorate samples with a `FOO` attribute holding a `BAR`value.
+Ie: `NRI_{INTEGRATION_NAME}_FOO=BAR` will decorate samples with a `FOO`
+attribute holding a `BAR` value.

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/data/inventory"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
@@ -21,7 +21,7 @@ type Entity struct {
 	storer      persist.Storer
 	lock        sync.Locker
 	// CustomAttributes []metric.Attribute `json:"custom_attributes,omitempty"`
-	customAttributes []attributes.Attribute
+	customAttributes []attribute.Attribute
 }
 
 // EntityMetadata stores entity Metadata
@@ -110,7 +110,7 @@ func (e *Entity) SameAs(b *Entity) bool {
 }
 
 // NewMetricSet returns a new instance of Set with its sample attached to the integration.
-func (e *Entity) NewMetricSet(eventType string, nameSpacingAttributes ...attributes.Attribute) *metric.Set {
+func (e *Entity) NewMetricSet(eventType string, nameSpacingAttributes ...attribute.Attribute) *metric.Set {
 
 	s := metric.NewSet(eventType, e.storer, nameSpacingAttributes...)
 
@@ -148,14 +148,14 @@ func (e *Entity) SetInventoryItem(key string, field string, value interface{}) e
 }
 
 // AddAttributes adds attributes to every entity metric-set.
-func (e *Entity) AddAttributes(attributes ...attributes.Attribute) {
+func (e *Entity) AddAttributes(attributes ...attribute.Attribute) {
 	for _, a := range attributes {
 		e.setCustomAttribute(a.Key, a.Value)
 	}
 }
 
 func (e *Entity) setCustomAttribute(key string, value string) {
-	attribute := attributes.Attribute{
+	attribute := attribute.Attribute{
 		Key:   key,
 		Value: value,
 	}

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -155,7 +155,10 @@ func (e *Entity) AddAttributes(attributes ...attributes.Attribute) {
 }
 
 func (e *Entity) setCustomAttribute(key string, value string) {
-	attribute := attributes.Attribute{key, value}
+	attribute := attributes.Attribute{
+		Key:   key,
+		Value: value,
+	}
 	e.customAttributes = append(e.customAttributes, attribute)
 }
 

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewEntity(t *testing.T) {
@@ -106,16 +107,14 @@ func TestAddNotificationEvent(t *testing.T) {
 
 func TestAddEventWithAttributes(t *testing.T) {
 	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	en.customAttributes = attributes.Attributes{attributes.Attr("clusterName", "my-cluster-name")}
 	attrs := map[string]interface{}{"attrKey": "attrVal"}
 	err = en.AddEvent(event.NewWithAttributes("TestSummary", "TestCategory", attrs))
 	assert.NoError(t, err)
 
-	assert.Len(t, en.Events, 1)
+	require.Len(t, en.Events, 1)
 
 	assert.Equal(t, "TestSummary", en.Events[0].Summary)
 	assert.Equal(t, "TestCategory", en.Events[0].Category)

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -8,7 +8,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +71,7 @@ func TestEntity_AddAttributes(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	e.AddAttributes(attributes.Attr("key1", "val1"), attributes.Attr("key2", "val2"))
+	e.AddAttributes(attribute.Attr("key1", "val1"), attribute.Attr("key2", "val2"))
 
 	assert.Len(t, e.customAttributes, 2, "attributes should have been added to the entity")
 
@@ -93,7 +93,7 @@ func TestAddNotificationEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	en.customAttributes = attributes.Attributes{attributes.Attr("clusterName", "my-cluster-name")}
+	en.customAttributes = attribute.Attributes{attribute.Attr("clusterName", "my-cluster-name")}
 
 	err = en.AddEvent(event.NewNotification("TestSummary"))
 	assert.NoError(t, err)
@@ -109,7 +109,7 @@ func TestAddEventWithAttributes(t *testing.T) {
 	en, err := newEntity("Entity1", "Type1", persist.NewInMemoryStore(), false)
 	require.NoError(t, err)
 
-	en.customAttributes = attributes.Attributes{attributes.Attr("clusterName", "my-cluster-name")}
+	en.customAttributes = attribute.Attributes{attribute.Attr("clusterName", "my-cluster-name")}
 	attrs := map[string]interface{}{"attrKey": "attrVal"}
 	err = en.AddEvent(event.NewWithAttributes("TestSummary", "TestCategory", attrs))
 	assert.NoError(t, err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/newrelic/infra-integrations-sdk/data/attributes"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 
 	sdk_args "github.com/newrelic/infra-integrations-sdk/args"
@@ -160,7 +160,7 @@ func TestClusterAndServiceArgumentsAreAddedToMetadata(t *testing.T) {
 	e, err := i.Entity("name", "ns")
 	assert.NoError(t, err)
 
-	assert.Equal(t, []attributes.Attribute{
+	assert.Equal(t, []attribute.Attribute{
 		{
 			Key:   CustomAttrCluster,
 			Value: "foo",

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/newrelic/infra-integrations-sdk/data/attributes"
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 
 	sdk_args "github.com/newrelic/infra-integrations-sdk/args"
@@ -159,7 +160,7 @@ func TestClusterAndServiceArgumentsAreAddedToMetadata(t *testing.T) {
 	e, err := i.Entity("name", "ns")
 	assert.NoError(t, err)
 
-	assert.Equal(t, []metric.Attribute{
+	assert.Equal(t, []attributes.Attribute{
 		{
 			Key:   CustomAttrCluster,
 			Value: "foo",


### PR DESCRIPTION
#### Description of the changes

This PR allows events with attributes to be decorated with the entity `customAttributes` when they are added to via the `entity.AddEvent` function.

#### PR Review Checklist
### Author

- [x ] add a risk label after carefully considering the "blast radius" of your changes
- [x ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x ] assign at least one reviewer
- [x ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
