### PR TITLE
jmx multiline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - JMX package: fixed `nrjmx` error handling
+- JMX package support for `nrjmx` multi-line responses
 
 ## 3.4.0
 


### PR DESCRIPTION
#### Description of the changes

Adds:
- jmx multiline output support.
- remove line length limitation 

Status before:
- only first jmx stdout line was read, but there are cases where nrjmx will write several lines
- jmx package was reading nrjmx tool stdout and stderr into a limited buffer, so lines that does not fit into that size were silently dropped. This replaces buffered IO with unlimited stream read IO.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
