### PR TITLE
Remove JMX lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next
+
+### Changed
+
+- JMX does not support concurrency
+
 ## 3.4.0
 
 ### Added


### PR DESCRIPTION
#### Description of the changes

Remove JMX lock, as it does not support concurrency by design.

`jmx` package needs a whole re-design, starting by its API.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
