### PR TITLE
JMX: remove line length limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- JMX removed line length limitation
 - JMX does not support concurrency
 - JMX improved test readability, removed flaky test
 - JMX removed std channels unrequired close calls


### PR DESCRIPTION
#### Description of the changes

JMX: remove line length limitation

Status before this was that `jmx` package was reading `nrjmx` tool stdout and stderr into a limited buffer, so lines that does not fit into that size were silently dropped.

This replaces buffered IO with unlimited stream read IO.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
