### PR TITLE
JMX: custom nrjmx exec option + remove stderr closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - JMX no-auth connection
+- JMX constructor option to provice custom nrjmx tool executable
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - JMX removed std channels unrequired close calls
 - JMX better empty line comparison
 - JMX removed lock
+- JMX removed stderr fd closed error
 
 ### Fixed
 

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -130,6 +130,16 @@ func TestQuery_WithSSL(t *testing.T) {
 	}
 }
 
+func TestOpen_WithNrjmx(t *testing.T) {
+	aux := os.Getenv("NR_JMX_TOOL")
+	require.NoError(t, os.Unsetenv("NR_JMX_TOOL"))
+
+	assert.Error(t, OpenNoAuth("", "", WithNrJmxTool("/foo")), "/foo is not an executable")
+	assert.Equal(t, "/foo", cmd.Args[0])
+
+	require.NoError(t, os.Setenv("NR_JMX_TOOL", aux))
+}
+
 func TestJmxNoTimeoutQuery(t *testing.T) {
 	t.Skip("unreliable CI test")
 


### PR DESCRIPTION
#### Description of the changes

- JMX package  custom `nrjmx` executable tool option
- JMX package avoid nrjmx stderr closed error.

While reading from stderr, fd could have been closed by cmd.Wait, this is an expected error that doesn't cause any issue. We can safely ignore it.

> Going further this error comes from wrong jmx package API design, but this will be tackled in the future.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
