### PR TITLE
Jmx avoid stderr closed err

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -215,13 +215,14 @@ func handleStdErr(ctx context.Context) {
 		}
 
 		line, err = scanner.ReadString('\n')
-		if err != nil && err != io.EOF {
+		// API needs re to allow stderr full read before closing
+		if err != nil && err != io.EOF && !strings.Contains(err.Error(), "file already closed") {
 			log.Error(fmt.Sprintf("error reading stderr from JMX tool: %s", err.Error()))
 		}
 		if strings.HasPrefix(line, "WARNING") {
 			log.Warn(line[7:])
 		}
-		if err == io.EOF {
+		if err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
#### Description of the changes

JMX package avoid nrjmx stderr closed error.

While reading from stderr, fd could have been closed by `cmd.Wait`, this is an expected error that doesn't cause any issue. We can safely ignore it.

Going further this error comes from wrong `jmx` package API design, but this will be tackled in the future.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
