### PR TITLE
Fix jmx warning handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - JMX package: fixed `nrjmx` error handling
+- JMX package: fixed `nrjmx` warning handling
 - JMX package support for `nrjmx` multi-line responses
 
 ## 3.4.0

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -27,7 +27,7 @@ const (
 
 // Error vars to ease Query response handling.
 var (
-	BeanPatternErr = errors.New("cannot parse bean pattern")
+	ErrBeanPattern = errors.New("cannot parse bean pattern")
 )
 
 var cmd *exec.Cmd
@@ -40,7 +40,7 @@ var cmdWarnC = make(chan string, cmdStdChanLen)
 var done sync.WaitGroup
 
 var (
-	// DefaultNrjmxCommand default nrjmx tool executable path
+	// DefaultNrjmxExec default nrjmx tool executable path
 	DefaultNrjmxExec = "/usr/bin/nrjmx"
 	// ErrJmxCmdRunning error returned when trying to Open and nrjmx command is still running
 	ErrJmxCmdRunning = errors.New("JMX tool is already running")
@@ -240,11 +240,10 @@ func handleStdErr(ctx context.Context) {
 		if strings.HasPrefix(line, "WARNING") {
 			msg := line[7:]
 			if strings.Contains(msg, "Can't parse bean name") {
-				cmdErrC <- BeanPatternErr
+				cmdErrC <- ErrBeanPattern
 				return
-			} else {
-				cmdWarnC <- msg
 			}
+			cmdWarnC <- msg
 		}
 		if err != nil {
 			cmdErrC <- err

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	timeoutMillis = 1000
+	timeoutMillis = 1500
 	openAttempts  = 5
 	// jmx mock cmds
 	cmdEmpty         = "empty"
@@ -108,7 +108,7 @@ func TestQuery(t *testing.T) {
 func TestQuery_multipleLines(t *testing.T) {
 	require.NoError(t, openWait("", "", "", "", openAttempts))
 
-	result, err := Query(cmdMultiline, timeoutMillis)
+	result, err := Query(cmdMultiline, timeoutMillis*2)
 	require.NoError(t, err)
 	Close()
 

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -199,8 +199,8 @@ func Test_receiveResult_warningsDoNotBreakResultReception(t *testing.T) {
 
 	_, _ = receiveResult(resultCh, queryErrCh, cancelFn, "empty", outTimeout)
 
-	cmdExitErr <- fmt.Errorf("WARNING foo bar")
-	assert.Equal(t, <-cmdExitErr, fmt.Errorf("WARNING foo bar"))
+	cmdErrC <- fmt.Errorf("WARNING foo bar")
+	assert.Equal(t, <-cmdErrC, fmt.Errorf("WARNING foo bar"))
 
 	resultCh <- []byte("{foo}")
 	assert.Equal(t, string(<-resultCh), "{foo}")


### PR DESCRIPTION
#### Description of the changes

1. Added verbose log mode
2. Fixed `jmx` package  warning handling
3. Converted "bean pattern error" from warning to proper error

**2) Detail:**
Previously `nrjmx` warning output was just logged. Then Query waited for cmd timeout returning an error. Now a warning avoids waiting for timeout returning nil and logging on Warning level.

> Once we change jmx pacakge API, this should be modified so Query fn could return proper error/warning types.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
