### PR TITLE
JMX restore single nrjmx line ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - JMX package: fixed `nrjmx` error handling
 - JMX package: fixed `nrjmx` warning handling
-- JMX package support for `nrjmx` multi-line responses
+- JMX package support for `nrjmx` stderr multi-line responses
 
 ## 3.4.0
 

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -283,7 +283,9 @@ func handleStdErr(ctx context.Context) {
 // Close will finish the underlying nrjmx application by closing its standard
 // input and canceling the execution afterwards to clean-up.
 func Close() {
-	cancel()
+	if cancel != nil {
+		cancel()
+}
 
 	done.Wait()
 }

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -27,8 +27,8 @@ const (
 
 // Error vars to ease Query response handling.
 var (
-	ErrBeanPattern = errors.New("cannot parse bean pattern")
-	ErrConnection  = errors.New("cannot connect")
+	ErrBeanPattern = errors.New("cannot parse MBean glob pattern, valid: 'DOMAIN:BEAN'")
+	ErrConnection  = errors.New("jmx endpoint connection error")
 )
 
 var cmd *exec.Cmd
@@ -285,7 +285,7 @@ func handleStdErr(ctx context.Context) {
 func Close() {
 	if cancel != nil {
 		cancel()
-}
+	}
 
 	done.Wait()
 }

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -311,9 +311,7 @@ func doQuery(ctx context.Context, out chan []byte, queryErrC chan error, querySt
 			queryErrC <- fmt.Errorf("reading nrjmx stdout: %s", err.Error())
 		}
 		out <- b
-		if err != nil {
-			return
-		}
+		return
 	}
 }
 

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -24,17 +24,7 @@ const (
 	cmdTimeout       = "timeout"
 	cmdBigPayload    = "bigPayload"
 	cmdBigPayloadErr = "bigPayloadError"
-	cmdMultiline     = "multiline"
-	resultMultiline  = `{"test:type\u003dSomeType,name\u003dFoo,attr\u003dName":"Foo","test:type\u003dSomeType,name\u003dBar,attr\u003dName":"Bar"}
-{"test:type\u003dSomeType,name\u003dBaz,attr\u003dName":"Baz","test:type\u003dSomeType,name\u003dQux,attr\u003dName":"Qux"}`
 )
-
-var expectedOutputMultiline = map[string]interface{}{
-	"test:type=SomeType,name=Foo,attr=Name": "Foo",
-	"test:type=SomeType,name=Bar,attr=Name": "Bar",
-	"test:type=SomeType,name=Baz,attr=Name": "Baz",
-	"test:type=SomeType,name=Qux,attr=Name": "Qux",
-}
 
 var query2IsErr = map[string]bool{
 	cmdEmpty:   false,
@@ -73,8 +63,6 @@ func TestMain(m *testing.M) {
 			} else if command == cmdBigPayloadErr {
 				// Create a payload of more than 4M
 				fmt.Println(fmt.Sprintf("{\"first\": 1%s}", strings.Repeat(", \"s\": 2", 4*1024*1024)))
-			} else if command == cmdMultiline {
-				fmt.Println(resultMultiline)
 			}
 
 		}
@@ -105,22 +93,12 @@ func TestQuery(t *testing.T) {
 
 		_, err := Query(q, timeoutMillis)
 		if isErr {
-			assert.Error(t, err)
+			assert.Error(t, err, "case "+q)
 		} else {
-			assert.NoError(t, err)
+			assert.NoError(t, err, "case "+q)
 		}
 		Close()
 	}
-}
-
-func TestQuery_multipleLines(t *testing.T) {
-	require.NoError(t, openWait("", "", "", "", openAttempts))
-
-	result, err := Query(cmdMultiline, timeoutMillis*2)
-	require.NoError(t, err)
-	Close()
-
-	assert.Equal(t, expectedOutputMultiline, result)
 }
 
 func TestQuery_WithSSL(t *testing.T) {


### PR DESCRIPTION
#### Description of the changes

JMX: restoring `nrjmx` stdout single line ingestion.

This rolls back `nrjmx` stdout multiline support (still not released) to speed up querying, as multiline support seems to be not required.

`nrjmx` stderr ingest multiline is kept as a query error can write several lines into stderr.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
