### PR TITLE
Stop reading from stdOut after receiving message

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -311,9 +311,7 @@ func doQuery(ctx context.Context, out chan []byte, queryErrC chan error, querySt
 			queryErrC <- fmt.Errorf("reading nrjmx stdout: %s", err.Error())
 		}
 		out <- b
-		if err != nil {
-			return
-		}
+		return
 	}
 }
 


### PR DESCRIPTION
Previously, `doQuery` was only returning when an EOF was encountered.
However, this causes issues when multiple queries are to be sent to the
`nrjmx` process. Multiple `doQuery` goroutines were running at the
same time, and it appears the first one to run was always consuming
stdOut, which caused all remaining queries to fail with a timeout.

#### Description of the changes

Add a detailed description and purpose of your changes.
Link the issue it solves (if there is one).

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
