### PR TITLE
Removed panic when log.Fatal is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 *.prof
 
 coverage.xml
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next
 
+### Changed
+
+- Removed panic when calling ``log.Fatal``
+
 ### 3.6.0
 
 ### Added

--- a/log/log.go
+++ b/log/log.go
@@ -104,5 +104,5 @@ func Error(format string, args ...interface{}) {
 // Fatal logs an error at level Fatal, and makes the program exit with an error code.
 func Fatal(err error) {
 	globalLogger.prefixPrint("FATAL", "can't continue: %v", err)
-	panic(err)
+	os.Exit(1)
 }


### PR DESCRIPTION
#### Description of the changes

Removed panic call when `log.Fatal` is called, in favour of just calling `os.Exit(1)`; the same as the standard Go logging library does. 

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documentation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
