### PR TITLE
Fix for the global logger when in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 3.6.2
+
+### Fixed
+
+- Fix issue on the global logger to log debug messages when verbose is enabled.
+
 ### 3.6.1
 
 ### Changed

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -89,6 +89,10 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 	i.prettyOutput = defaultArgs.Pretty
 	i.addHostnameToMeta = defaultArgs.NriAddHostname
 
+	if defaultArgs.Verbose {
+		log.SetupLogging(defaultArgs.Verbose)
+	}
+
 	// Setting default values, if not set yet
 	if i.logger == nil {
 		i.logger = log.NewStdErr(defaultArgs.Verbose)

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -98,6 +98,10 @@ func (cfg *connectionConfig) command() []string {
 		c = append(c, "--keyStore", cfg.keyStore, "--keyStorePassword", cfg.keyStorePassword, "--trustStore", cfg.trustStore, "--trustStorePassword", cfg.trustStorePassword)
 	}
 
+	if cfg.verbose {
+		c = append(c, "--verbose")
+	}
+
 	return c
 }
 
@@ -125,8 +129,6 @@ func Open(hostname, port, username, password string, opts ...Option) error {
 	for _, opt := range opts {
 		opt(config)
 	}
-
-	log.SetupLogging(config.verbose)
 
 	return openConnection(config)
 }


### PR DESCRIPTION
#### Description of the changes

This PR will fix the issue in the global logger which caused the debug messages to be discarded when verbose mode was enabled.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
