### PR TITLE
Add jmx client error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Return jmx client error when nrjxm fail to connect or exited and can not continue.
+- Improvement for jmx error handling.
 
 ### 3.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 3.6.3
+
+### Fixed
+
+- Return jmx client error when nrjxm fail to connect or exited and can not continue.
+
 ### 3.6.2
 
 ### Fixed

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -51,6 +51,7 @@ func (j jmxClientError) Error() string {
 	return string(j)
 }
 
+// IsJmxClientError identify if the error is jmx client error type
 func IsJmxClientError(err error) bool {
 	_, ok := err.(jmxClientError)
 	return ok

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -237,9 +237,7 @@ func openConnection(config *connectionConfig) (err error) {
 
 	go func() {
 		if err = cmd.Wait(); err != nil {
-			if err != nil {
-				cmdErrC <- jmxClientError(fmt.Sprintf("nrjmx error: %s [proc-state: %s]", err, cmd.ProcessState))
-			}
+			cmdErrC <- jmxClientError(fmt.Sprintf("nrjmx error: %s [proc-state: %s]", err, cmd.ProcessState))
 		}
 
 		cmd = nil

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -23,15 +23,19 @@ import (
 const (
 	jmxLineInitialBuffer = 4 * 1024 // initial 4KB per line, it'll be increased when required
 	cmdStdChanLen        = 1000
+	defaultNrjmxExec     = "/usr/bin/nrjmx" // defaultNrjmxExec default nrjmx tool executable path
 )
 
 // Error vars to ease Query response handling.
 var (
 	ErrBeanPattern = errors.New("cannot parse MBean glob pattern, valid: 'DOMAIN:BEAN'")
-	ErrConnection  = errors.New("jmx endpoint connection error")
+	ErrConnection  = jmxClientError("jmx endpoint connection error")
+	// ErrJmxCmdRunning error returned when trying to Open and nrjmx command is still running
+	ErrJmxCmdRunning = errors.New("JMX tool is already running")
 )
 
 var cmd *exec.Cmd
+
 var cancel context.CancelFunc
 var cmdOut io.ReadCloser
 var cmdError io.ReadCloser
@@ -40,12 +44,17 @@ var cmdErrC = make(chan error, cmdStdChanLen)
 var cmdWarnC = make(chan string, cmdStdChanLen)
 var done sync.WaitGroup
 
-var (
-	// DefaultNrjmxExec default nrjmx tool executable path
-	DefaultNrjmxExec = "/usr/bin/nrjmx"
-	// ErrJmxCmdRunning error returned when trying to Open and nrjmx command is still running
-	ErrJmxCmdRunning = errors.New("JMX tool is already running")
-)
+// jmxClientError error is returned when the nrjmx tool can not continue
+type jmxClientError string
+
+func (j jmxClientError) Error() string {
+	return string(j)
+}
+
+func IsJmxClientError(err error) bool {
+	_, ok := err.(jmxClientError)
+	return ok
+}
 
 // connectionConfig is the configuration for the nrjmx command.
 type connectionConfig struct {
@@ -123,7 +132,7 @@ func Open(hostname, port, username, password string, opts ...Option) error {
 		port:           port,
 		username:       username,
 		password:       password,
-		executablePath: DefaultNrjmxExec,
+		executablePath: defaultNrjmxExec,
 	}
 
 	for _, opt := range opts {
@@ -228,7 +237,7 @@ func openConnection(config *connectionConfig) (err error) {
 	go func() {
 		if err = cmd.Wait(); err != nil {
 			if err != nil {
-				cmdErrC <- fmt.Errorf("nrjmx error: %s [proc-state: %s]", err, cmd.ProcessState)
+				cmdErrC <- jmxClientError(fmt.Sprintf("nrjmx error: %s [proc-state: %s]", err, cmd.ProcessState))
 			}
 		}
 


### PR DESCRIPTION
#### Description of the changes

Return jmx client error when nrjmx integration connection failed or process exited. With this change we allow other integration to handle this error type.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] document feature

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] request documenation about anything that isn't clear and obvious
- [ ] document agent version supporting the feature
