### PR TITLE
feat(metrics): allow NaN and Inf

### DIFF
--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -1,6 +1,7 @@
 package metric
 
 import (
+	"math"
 	"time"
 
 	err "github.com/newrelic/infra-integrations-sdk/data/errors"
@@ -42,11 +43,11 @@ type count struct {
 // summary is a metric of type summary.
 type summary struct {
 	metricBase
-	Count   float64 `json:"count"`
-	Average float64 `json:"average"`
-	Sum     float64 `json:"sum"`
-	Min     float64 `json:"min"`
-	Max     float64 `json:"max"`
+	Count   *float64 `json:"count"`
+	Average *float64 `json:"average"`
+	Sum     *float64 `json:"sum"`
+	Min     *float64 `json:"min"`
+	Max     *float64 `json:"max"`
 }
 
 // cumulativeCount is a metric of type cumulative count
@@ -114,11 +115,11 @@ func NewSummary(timestamp time.Time, name string, count float64, average float64
 			Type:       SourcesTypeToName[SUMMARY],
 			Dimensions: Dimensions{},
 		},
-		Count:   count,
-		Average: average,
-		Sum:     sum,
-		Min:     min,
-		Max:     max,
+		Count:   asFloatPtr(count),
+		Average: asFloatPtr(average),
+		Sum:     asFloatPtr(sum),
+		Min:     asFloatPtr(min),
+		Max:     asFloatPtr(max),
 	}, nil
 }
 
@@ -194,4 +195,11 @@ func (m *metricBase) Dimension(key string) string {
 // GetDimensions gets all the dimensions
 func (m *metricBase) GetDimensions() Dimensions {
 	return m.Dimensions
+}
+
+func asFloatPtr(value float64) *float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return nil
+	}
+	return &value
 }

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -1,6 +1,7 @@
 package metric
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -161,4 +162,10 @@ func Test_Metric_CannotCreateCumulativeRateWithEmptyName(t *testing.T) {
 	cr, err := NewCumulativeRate(now, "", 110)
 	assert.Nil(t, cr)
 	assert.Error(t, err)
+}
+
+func Test_Metric_CanCreateSummaryWithNan(t *testing.T) {
+	s, err := NewSummary(now, "summary-with-nan", 1, math.NaN(), 10, math.NaN(), math.NaN())
+	assert.NotNil(t, s)
+	assert.NoError(t, err)
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"io/ioutil"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -240,6 +241,30 @@ func Test_Integration_PublishThrowsNoError(t *testing.T) {
 				  "events": []
 				},
 				{
+				  "common":{},
+				  "entity": {
+					"name": "EntityThree",
+					"displayName":"",
+					"type": "test",
+					"metadata": {}
+				  },
+				  "metrics": [
+					{
+						"timestamp": 10000000,
+						"name": "metric-summary-with-nan",
+						"type": "summary",
+						"attributes": {},
+						"count": 1,
+						"average": null,
+						"sum": 100,
+						"min": null,
+						"max": null
+					}
+				  ],
+				  "inventory": {},
+				  "events": []
+				},
+				{
 				  "common": {},
                   "metrics": [
 				   {
@@ -348,6 +373,15 @@ func Test_Integration_PublishThrowsNoError(t *testing.T) {
 	// add a cumulative rate metric to the host entity
 	crate, _ := CumulativeRate(time.Unix(10000000, 0), "cumulative-rate", 120)
 	i.HostEntity.AddMetric(crate)
+
+	// add entity 3
+	e3, err := i.NewEntity("EntityThree", "test", "")
+	assert.NoError(t, err)
+	// add metric to entity 2
+	summary2, _ := Summary(time.Unix(10000000, 0), "metric-summary-with-nan", 1, math.NaN(), 100, math.NaN(), math.NaN())
+	e3.AddMetric(summary2)
+	// add entity 3 to integration
+	i.AddEntity(e3)
 
 	assert.NoError(t, i.Publish())
 


### PR DESCRIPTION
Nan or Inf values can be passed for summary metrics and will be serialized as null in the json output