### PR TITLE
Fix rates to be calculated for PRATE source types as well

### DIFF
--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -169,7 +169,7 @@ func (ms *Set) elapsedDifference(name string, absolute interface{}, sourceType S
 		return
 	}
 
-	if sourceType == RATE {
+	if sourceType == RATE || sourceType == PRATE {
 		elapsed = elapsed / float64(duration)
 	}
 


### PR DESCRIPTION
While using the nri-haproxy integration I've noticed the rates for connections per second, bytes per second, and other things that were defined as type PRATE were all wrong.  I could manually collect statistics for HAProxy and calculate rates and nothing lined up with what the integration calculated.  On further inspection, I found in the SDK that if a metric was defined as a source type of PRATE, it was not actually having a rate calculated for it.  This PR fixes this problem.  The one line code fix ensures that rates are calculated for a source type of RATE or PRATE.