### PR TITLE
feat(integration): add find entity by name

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -176,6 +176,24 @@ func (i *Integration) Logger() log.Logger {
 	return i.logger
 }
 
+// FindEntity finds ad return an entity by name. returns false if entity does not exist in the integration
+func (i *Integration) FindEntity(name string) (*Entity, bool) {
+	if i.Entities == nil {
+		return &Entity{}, false
+	}
+	for _, e := range i.Entities {
+		// nil metadata usually means the "host" entity, so keep searching
+		if e == nil || e.Metadata == nil {
+			continue
+		}
+
+		if e.Metadata.Name == name {
+			return e, true
+		}
+	}
+	return &Entity{}, false
+}
+
 // Gauge creates a metric of type gauge
 func Gauge(timestamp time.Time, metricName string, value float64) (metric.Metric, error) {
 	return metric.NewGauge(timestamp, metricName, value)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -110,7 +110,7 @@ func Test_Integration_EntitiesWithDifferentTagsAreNotEqual(t *testing.T) {
 	assert.True(t, e1.SameAs(e3), "Same metadata creates/retrieves same entity")
 }
 
-func Test_Integration_NewEntityReturnsExistingEntity(t *testing.T) {
+func Test_Integration_EntitiesWithSameMetadataAreTheSame(t *testing.T) {
 	i := newTestIntegration(t)
 
 	e1, err := i.NewEntity("Entity1", "test", "")
@@ -433,6 +433,27 @@ func Test_Integration_PublishThrowsNoError(t *testing.T) {
 
 	// check integration  was reset
 	assert.Empty(t, i.Entities)
+}
+
+func Test_Integration_FindEntity(t *testing.T) {
+	i := newTestIntegration(t)
+
+	_, found := i.FindEntity("some-entity-name")
+	assert.False(t, found)
+
+	e, err := i.NewEntity("some-entity-name", "test", "")
+	assert.NoError(t, err)
+	assert.NotNil(t, e)
+	// not added yet
+	_, found = i.FindEntity("some-entity-name")
+	assert.False(t, found)
+
+	i.AddEntity(e)
+	// after adding
+	assert.Len(t, i.Entities, 1)
+	e1, found1 := i.FindEntity("some-entity-name")
+	assert.True(t, found1)
+	assert.True(t, e.SameAs(e1))
 }
 
 //--- helpers


### PR DESCRIPTION
This add support for finding an entity by name. This is required to avoid adding metrics belonging to the same entity in different entity entries (although they would end up being the same entity) and reducing the overall payload