### PR TITLE
fix: Rename value annotation for count metric.

### DIFF
--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -37,7 +37,7 @@ type gauge struct {
 // This indicates to the Infra agent that the value should be interpreted as a count that is reset in each interval
 type count struct {
 	metricBase
-	Value float64 `json:"count"`
+	Value float64 `json:"value"`
 }
 
 // summary is a metric of type summary.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -179,7 +179,7 @@ func Test_Integration_PublishThrowsNoError(t *testing.T) {
 					  "attributes": {
 						"cpu": "amd"
 					  },
-					  "count": 100
+					  "value": 100
 					},
 					{
 					  "timestamp": 10000000,
@@ -276,7 +276,7 @@ func Test_Integration_PublishThrowsNoError(t *testing.T) {
 					  "name": "cumulative-count",
 					  "type": "cumulative-count",
 					  "attributes": {},
-					  "count": 120
+					  "value": 120
 					},
 					{
 					  "timestamp": 10000000,


### PR DESCRIPTION
The json annotation was wrongly named count. the agent expect the field `value`