### PR TITLE
Allow entities to be removed from the integration payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Package `http` can now create a client that validate certificates but also
   accepts invalid hostnames via `NewAcceptInvalidHostname`.
+- Allow entities to be removed from the integration payload with `integration.RemoveEntity`
 
 ### 3.6.3
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -190,7 +190,7 @@ func (i *Integration) Entity(name, namespace string, idAttributes ...IDAttribute
 }
 
 // RemoveEntity removes entity from the inner entity slice.
-func (i *Integration) RemoveEntity(entity Entity) {
+func (i *Integration) RemoveEntity(entity *Entity) {
 	i.locker.Lock()
 	defer i.locker.Unlock()
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -189,6 +189,23 @@ func (i *Integration) Entity(name, namespace string, idAttributes ...IDAttribute
 	return e, nil
 }
 
+// RemoveEntity removes entity from the inner entity slice.
+func (i *Integration) RemoveEntity(entity Entity) {
+	i.locker.Lock()
+	defer i.locker.Unlock()
+
+	var entityIdx int
+	for idx, ent := range i.Entities {
+		if entity.SameAs(ent) {
+			entityIdx = idx
+			break
+		}
+	}
+	// Trick to remove an item from a slice and reduce its size properly.
+	i.Entities[entityIdx] = i.Entities[len(i.Entities)-1]
+	i.Entities = i.Entities[:len(i.Entities)-1]
+}
+
 // Publish runs all necessary tasks before publishing the data. Currently, it
 // stores the Storer, prints the JSON representation of the integration using a writer (stdout by default)
 // and re-initializes the integration object (allowing re-use it during the

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -82,6 +82,17 @@ func TestIntegration_Entity(t *testing.T) {
 	assert.Equal(t, e1, e3, "Same namespace & name create/retrieve same entity")
 }
 
+func TestIntegration_RemoveEntity(t *testing.T) {
+	i := newTestIntegration(t)
+
+	e1, err := i.Entity("name", "ns")
+	assert.NoError(t, err)
+	assert.Contains(e1, i.Entities, "Entity is in the list.")
+
+	i.RemoveEntity(e1)
+	assert.NotContains(e1, i.Entities, "Entity removed from the list.")
+}
+
 func TestIntegration_Entity_WithIDAttrs(t *testing.T) {
 	i := newTestIntegration(t)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -87,10 +87,10 @@ func TestIntegration_RemoveEntity(t *testing.T) {
 
 	e1, err := i.Entity("name", "ns")
 	assert.NoError(t, err)
-	assert.Contains(e1, i.Entities, "Entity is in the list")
+	assert.Contains(t, e1, i.Entities, "Entity is in the list")
 
 	i.RemoveEntity(e1)
-	assert.NotContains(e1, i.Entities, "Entity is not in the list")
+	assert.NotContains(t, e1, i.Entities, "Entity is not in the list")
 }
 
 func TestIntegration_Entity_WithIDAttrs(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -87,10 +87,10 @@ func TestIntegration_RemoveEntity(t *testing.T) {
 
 	e1, err := i.Entity("name", "ns")
 	assert.NoError(t, err)
-	assert.Contains(e1, i.Entities, "Entity is in the list.")
+	assert.Contains(e1, i.Entities, "Entity is in the list")
 
 	i.RemoveEntity(e1)
-	assert.NotContains(e1, i.Entities, "Entity removed from the list.")
+	assert.NotContains(e1, i.Entities, "Entity is not in the list")
 }
 
 func TestIntegration_Entity_WithIDAttrs(t *testing.T) {


### PR DESCRIPTION
This allows users of the SDK to safely delete entities from the integrations payload. 

It's impossible to do this safely outside of the SDK, as the lock used for changing the entity slice is not exported.