### PR TITLE
fix: warning stops mbeans processing

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -390,9 +390,7 @@ func logAvailableWarnings(channel chan string) {
 	for {
 		select {
 		case warn = <-channel:
-			{
-				log.Warn(warn)
-			}
+			log.Warn(warn)
 		default:
 			return
 		}

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -342,7 +342,7 @@ func Query(objectPattern string, timeoutMillis int) (result map[string]interface
 
 // receiveResult checks for channels to receive result from nrjmx command.
 func receiveResult(lineC chan []byte, queryErrC chan error, cancelFn context.CancelFunc, objectPattern string, timeout time.Duration) (result map[string]interface{}, err error) {
-	defer logAvailableWarnings()
+	defer logAvailableWarnings(cmdWarnC)
 	var warn string
 	for {
 		select {
@@ -385,12 +385,11 @@ func receiveResult(lineC chan []byte, queryErrC chan error, cancelFn context.Can
 	}
 }
 
-func logAvailableWarnings() {
+func logAvailableWarnings(channel chan string) {
 	var warn string
 	for {
-
 		select {
-		case warn = <-cmdWarnC:
+		case warn = <-channel:
 			{
 				log.Warn(warn)
 			}

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -323,6 +323,7 @@ func doQuery(ctx context.Context, out chan []byte, queryErrC chan error, querySt
 			queryErrC <- fmt.Errorf("reading nrjmx stdout: %s", err.Error())
 		}
 		out <- b
+		return
 	}
 }
 

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -342,6 +342,7 @@ func Query(objectPattern string, timeoutMillis int) (result map[string]interface
 // receiveResult checks for channels to receive result from nrjmx command.
 func receiveResult(lineC chan []byte, queryErrC chan error, cancelFn context.CancelFunc, objectPattern string, timeout time.Duration) (result map[string]interface{}, err error) {
 	defer logAvailableWarnings()
+	var warn string
 	for {
 		select {
 		case line := <-lineC:
@@ -363,6 +364,9 @@ func receiveResult(lineC chan []byte, queryErrC chan error, cancelFn context.Can
 			}
 
 			return
+
+		case warn = <-cmdWarnC:
+			log.Warn(warn)
 
 		case err = <-cmdErrC:
 			return

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -6,12 +6,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/newrelic/infra-integrations-sdk/v4/log"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/newrelic/infra-integrations-sdk/v4/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -2,9 +2,11 @@ package jmx
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
+	"github.com/newrelic/infra-integrations-sdk/v4/log"
 	"os"
 	"strings"
 	"testing"
@@ -179,17 +181,25 @@ func openWaitWithSSL(hostname, port, username, password, keyStore, keyStorePassw
 }
 
 func Test_receiveResult_warningsDoNotBreakResultReception(t *testing.T) {
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
 	_, cancelFn := context.WithCancel(context.Background())
 
 	resultCh := make(chan []byte, 1)
 	queryErrCh := make(chan error)
 	outTimeout := time.Duration(timeoutMillis) * time.Millisecond
+	warningMessage := fmt.Sprint("WARNING foo bar")
+	cmdWarnC <- warningMessage
 
-	_, _ = receiveResult(resultCh, queryErrCh, cancelFn, "empty", outTimeout)
+	resultCh <- []byte("{\"foo\":1}")
 
-	cmdErrC <- fmt.Errorf("WARNING foo bar")
-	assert.Equal(t, <-cmdErrC, fmt.Errorf("WARNING foo bar"))
+	result, err := receiveResult(resultCh, queryErrCh, cancelFn, "foo", outTimeout)
 
-	resultCh <- []byte("{foo}")
-	assert.Equal(t, string(<-resultCh), "{foo}")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": 1.,
+	}, result)
+	assert.Equal(t, fmt.Sprintf("[WARN] %s\n", warningMessage), buf.String())
 }

--- a/log/log.go
+++ b/log/log.go
@@ -81,6 +81,7 @@ func SetupLogging(verbose bool) {
 	}
 }
 
+// SetOutput sets output stream
 func SetOutput(w io.Writer) {
 	globalLogger.logger.SetOutput(w)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -81,6 +81,10 @@ func SetupLogging(verbose bool) {
 	}
 }
 
+func SetOutput(w io.Writer) {
+	globalLogger.logger.SetOutput(w)
+}
+
 // Debug logs a formatted message at level Debug.
 func Debug(format string, args ...interface{}) {
 	globalLogger.Debugf(format, args...)


### PR DESCRIPTION
Problem: when SDK receives any warning from NRJMX integration, it stops to process remaining data. It has race condition inside, so sometimes it will process data first and exits, in some cases it will print warning first and exits.

Solution: make warning processing not terminating case (remove return from warning case) and add all warnings processing function to call as a defer for all return cases. This will help us with behaviour consistency

Chore: add SetOutput function for a logger, to be able to replace output stream for tests