### PR TITLE
Add jmx package fixes to v3 branch

### DIFF
--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -188,6 +188,8 @@ func Test_receiveResult_warningsDoNotBreakResultReception(t *testing.T) {
 
 	_, cancelFn := context.WithCancel(context.Background())
 
+	// clean cmdErrC global variable to avoid test fail on different execution orders.
+	cmdErrC = make(chan error, cmdStdChanLen)
 	resultCh := make(chan []byte, 1)
 	queryErrCh := make(chan error)
 	outTimeout := time.Duration(timeoutMillis) * time.Millisecond

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -189,18 +190,29 @@ func Test_receiveResult_warningsDoNotBreakResultReception(t *testing.T) {
 
 	resultCh := make(chan []byte, 1)
 	queryErrCh := make(chan error)
-	cmdErrC := make(chan error)
 	outTimeout := time.Duration(timeoutMillis) * time.Millisecond
 	warningMessage := fmt.Sprint("WARNING foo bar")
 	cmdWarnC <- warningMessage
 
 	resultCh <- []byte("{\"foo\":1}")
 
-	result, err := receiveResult(resultCh, cmdErrC, queryErrCh, cancelFn, "foo", outTimeout)
+	result, err := receiveResult(resultCh, queryErrCh, cancelFn, "foo", outTimeout)
 
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
 		"foo": 1.,
 	}, result)
 	assert.Equal(t, fmt.Sprintf("[WARN] %s\n", warningMessage), buf.String())
+}
+
+func Test_DefaultPath_IsCorrectForOs(t *testing.T) {
+	os := runtime.GOOS
+	switch os {
+	case "windows":
+	case "darwin":
+	case "linux":
+		assert.True(t, len(defaultNrjmxExec) > 0)
+	default:
+		t.Fatal("unexpected value")
+	}
 }

--- a/jmx/jmx_unix.go
+++ b/jmx/jmx_unix.go
@@ -1,0 +1,11 @@
+// +build linux darwin
+
+/*
+Package jmx is a library to get metrics through JMX. It requires additional
+setup. Read https://github.com/newrelic/infra-integrations-sdk#jmx-support for
+instructions. */
+package jmx
+
+const (
+	defaultNrjmxExec = "/usr/bin/nrjmx" // defaultNrjmxExec default nrjmx tool executable path
+)

--- a/jmx/jmx_windows.go
+++ b/jmx/jmx_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+/*
+Package jmx is a library to get metrics through JMX. It requires additional
+setup. Read https://github.com/newrelic/infra-integrations-sdk#jmx-support for
+instructions. */
+package jmx
+
+const (
+	defaultNrjmxExec = "c:\\progra~1\\newrel~1\\nrjmx\\nrjmx.bat" // defaultNrjmxExec default nrjmx tool executable path
+)

--- a/log/log.go
+++ b/log/log.go
@@ -81,6 +81,11 @@ func SetupLogging(verbose bool) {
 	}
 }
 
+// SetOutput sets output stream
+func SetOutput(w io.Writer) {
+	globalLogger.logger.SetOutput(w)
+}
+
 // Debug logs a formatted message at level Debug.
 func Debug(format string, args ...interface{}) {
 	globalLogger.Debugf(format, args...)


### PR DESCRIPTION
I have created a v3 branch that should be used to track all patches and tag the following versions of the SDK v3.X

This PR adds:
* Cherry picked commit e4dedaa
* Add lastest fixes on v4 786cf26 on the jmx package


After review-merge of this PR to v3 we should that branch with `v3.6.6` release and that Fixes #261 