### PR TITLE
Add JMX host and port getters so can be retrieved in the integrations when a connection query fails

### DIFF
--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -44,6 +44,9 @@ var cmdErrC = make(chan error, cmdStdChanLen)
 var cmdWarnC = make(chan string, cmdStdChanLen)
 var done sync.WaitGroup
 
+var jmxHost string
+var jmxPort string
+
 // jmxClientError error is returned when the nrjmx tool can not continue
 type jmxClientError string
 
@@ -214,6 +217,9 @@ func openConnection(config *connectionConfig) (err error) {
 	var ctx context.Context
 
 	cliCommand := config.command()
+
+	jmxHost = config.hostname
+	jmxPort = config.port
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cmd = exec.CommandContext(ctx, cliCommand[0], cliCommand[1:]...)
@@ -395,4 +401,14 @@ func logAvailableWarnings(channel chan string) {
 			return
 		}
 	}
+}
+
+// HostName returns the host the nrjmx is connected to
+func HostName() string {
+	return jmxHost
+}
+
+// Port returns the port the nrjmx is connected to
+func Port() string {
+	return jmxPort
 }

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -122,6 +122,8 @@ func TestQuery_WithSSL(t *testing.T) {
 }
 
 func TestOpen_WithNrjmx(t *testing.T) {
+	defer Close()
+
 	aux := os.Getenv("NR_JMX_TOOL")
 	require.NoError(t, os.Unsetenv("NR_JMX_TOOL"))
 
@@ -217,4 +219,18 @@ func Test_DefaultPath_IsCorrectForOs(t *testing.T) {
 	default:
 		t.Fatal("unexpected value")
 	}
+}
+
+func TestHostName(t *testing.T) {
+	defer Close()
+	host := "a-host"
+	assert.NoError(t, OpenNoAuth(host, ""))
+	assert.Equal(t, host, HostName())
+}
+
+func TestPort(t *testing.T) {
+	defer Close()
+	port := "6666"
+	assert.NoError(t, OpenNoAuth("", port))
+	assert.Equal(t, port, Port())
 }


### PR DESCRIPTION
- add host and port getters so can be retrieved in the integrations when a connection query fails