### PR TITLE
jmx: wrap nrjmx errors so error details are not lost

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -54,7 +54,6 @@ github.com/newrelic/infrastructure-agent v0.0.0-20201127092132-00ac7efc0cc6 h1:o
 github.com/newrelic/infrastructure-agent v0.0.0-20201127092132-00ac7efc0cc6/go.mod h1:OC9Em8HnZsHI3JQzMHFqfB4B7OBzQ2+gBffhS0Ip+pk=
 github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.2-0.20181029102219-09950c5fb1bb/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/jmx/jmx.go
+++ b/jmx/jmx.go
@@ -269,7 +269,7 @@ func handleStdErr(ctx context.Context) {
 		if strings.HasPrefix(line, "WARNING") {
 			msg := line[7:]
 			if strings.Contains(msg, "Can't parse bean name") {
-				cmdErrC <- ErrBeanPattern
+				cmdErrC <- fmt.Errorf("%w: %s", ErrBeanPattern, msg)
 				return
 			}
 			cmdWarnC <- msg
@@ -277,7 +277,7 @@ func handleStdErr(ctx context.Context) {
 		if strings.HasPrefix(line, "SEVERE:") {
 			msg := line[7:]
 			if strings.Contains(msg, "jmx connection error") {
-				cmdErrC <- ErrConnection
+				cmdErrC <- fmt.Errorf("%w: %s", ErrConnection, msg)
 			} else {
 				cmdErrC <- errors.New(msg)
 			}
@@ -354,7 +354,7 @@ func receiveResult(lineC chan []byte, queryErrC chan error, cancelFn context.Can
 			}
 			var r map[string]interface{}
 			if err = json.Unmarshal(line, &r); err != nil {
-				err = fmt.Errorf("invalid return value for query: %s, error: %s, line: %s", objectPattern, err, line)
+				err = fmt.Errorf("invalid return value for query: %s, error: %w, line: %q", objectPattern, err, line)
 				return
 			}
 			if result == nil {


### PR DESCRIPTION
Motivated by the following line in the agent log:

`[ERR] Connection error for catalogone-kafka-prod3-east.vpc.verizon.com:9999 : jmx endpoint connection error\n`

Which doesn't really help to know the cause of the connection error.

If you agree with the change, I can port the commit to the `v3` branch as well.