### PR TITLE
POC Interface for adding metrics without entity

### DIFF
--- a/integration/entity.go
+++ b/integration/entity.go
@@ -11,8 +11,8 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v4/data/metric"
 )
 
-// Entity is the producer of the data. Entity could be a host, a container, a pod, or whatever unit of meaning.
-type Entity struct {
+// DataSet is the producer of the data. DataSet could be a host, a container, a pod, or whatever unit of meaning.
+type DataSet struct {
 	CommonDimensions Common               `json:"common"` // dimensions common to every entity metric
 	Metadata         *metadata.Metadata   `json:"entity,omitempty"`
 	Metrics          metric.Metrics       `json:"metrics"`
@@ -31,7 +31,7 @@ type Common struct {
 }
 
 // SameAs return true when is same entity
-func (e *Entity) SameAs(b *Entity) bool {
+func (e *DataSet) SameAs(b *DataSet) bool {
 	if e.Metadata == nil || b.Metadata == nil {
 		return false
 	}
@@ -40,7 +40,7 @@ func (e *Entity) SameAs(b *Entity) bool {
 }
 
 // AddMetric adds a new metric to the entity metrics list
-func (e *Entity) AddMetric(metric metric.Metric) {
+func (e *DataSet) AddMetric(metric metric.Metric) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -48,7 +48,7 @@ func (e *Entity) AddMetric(metric metric.Metric) {
 }
 
 // AddEvent method adds a new Event.
-func (e *Entity) AddEvent(event *event.Event) {
+func (e *DataSet) AddEvent(event *event.Event) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -56,7 +56,7 @@ func (e *Entity) AddEvent(event *event.Event) {
 }
 
 // AddInventoryItem method sets the inventory item (only one allowed).
-func (e *Entity) AddInventoryItem(key string, field string, value interface{}) error {
+func (e *DataSet) AddInventoryItem(key string, field string, value interface{}) error {
 	if len(key) == 0 || len(field) == 0 {
 		return errors.New("key or field cannot be empty")
 	}
@@ -66,7 +66,7 @@ func (e *Entity) AddInventoryItem(key string, field string, value interface{}) e
 }
 
 // AddCommonDimension adds a new dimension to every metric within the entity.
-func (e *Entity) AddCommonDimension(key string, value string) {
+func (e *DataSet) AddCommonDimension(key string, value string) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -74,7 +74,7 @@ func (e *Entity) AddCommonDimension(key string, value string) {
 }
 
 // AddCommonTimestamp adds a new common timestamp to the entity.
-func (e *Entity) AddCommonTimestamp(timestamp time.Time) {
+func (e *DataSet) AddCommonTimestamp(timestamp time.Time) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -83,7 +83,7 @@ func (e *Entity) AddCommonTimestamp(timestamp time.Time) {
 }
 
 // AddCommonInterval adds a common interval in milliseconds from a time.Duration (nanoseconds).
-func (e *Entity) AddCommonInterval(timestamp time.Duration) {
+func (e *DataSet) AddCommonInterval(timestamp time.Duration) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -92,12 +92,12 @@ func (e *Entity) AddCommonInterval(timestamp time.Duration) {
 }
 
 // GetMetadata returns all the Entity's metadata
-func (e *Entity) GetMetadata() metadata.Map {
+func (e *DataSet) GetMetadata() metadata.Map {
 	return e.Metadata.Metadata
 }
 
 // AddTag adds a new tag to the entity
-func (e *Entity) AddTag(key string, value interface{}) error {
+func (e *DataSet) AddTag(key string, value interface{}) error {
 	if len(key) == 0 {
 		return errors.New("key cannot be empty")
 	}
@@ -106,7 +106,7 @@ func (e *Entity) AddTag(key string, value interface{}) error {
 }
 
 // AddMetadata adds a new metadata to the entity
-func (e *Entity) AddMetadata(key string, value interface{}) error {
+func (e *DataSet) AddMetadata(key string, value interface{}) error {
 	if len(key) == 0 {
 		return errors.New("key cannot be empty")
 	}
@@ -115,15 +115,15 @@ func (e *Entity) AddMetadata(key string, value interface{}) error {
 }
 
 // Name is the unique entity identifier within a New Relic customer account.
-func (e *Entity) Name() string {
+func (e *DataSet) Name() string {
 	return e.Metadata.Name
 }
 
 //--- private
 
 // newHostEntity creates a entity without metadata.
-func newHostEntity() *Entity {
-	return &Entity{
+func newHostEntity() *DataSet {
+	return &DataSet{
 		CommonDimensions: Common{
 			Attributes: make(map[string]interface{}),
 		},
@@ -136,13 +136,12 @@ func newHostEntity() *Entity {
 }
 
 // isHostEntity returns true if entity has no metadata
-func (e *Entity) isHostEntity() bool {
+func (e *DataSet) isHostEntity() bool {
 	return e.Metadata == nil || e.Metadata.Name == ""
 }
 
 // newEntity creates a new entity with with metadata.
-func newEntity(name, entityType string, displayName string) (*Entity, error) {
-
+func newEntity(name, entityType string, displayName string) (*DataSet, error) {
 	if name == "" || entityType == "" {
 		return nil, errors.New("entity name and type cannot be empty")
 	}

--- a/integration/entity.go
+++ b/integration/entity.go
@@ -19,6 +19,8 @@ type DataSet struct {
 	Inventory        *inventory.Inventory `json:"inventory"`
 	Events           event.Events         `json:"events"`
 	lock             sync.Locker
+
+	IgnoreHostEntity bool `json:"ignore_host_entity"`
 }
 
 // Common is the producer of the common dimensions/attributes.

--- a/integration/entity_test.go
+++ b/integration/entity_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func Test_Entity_NewEntityInitializesCorrectly(t *testing.T) {
-
 	e, err := newEntity("name", "type", "displayName")
 
 	assert.NoError(t, err)
@@ -28,7 +27,6 @@ func Test_Entity_NewEntityInitializesCorrectly(t *testing.T) {
 	assert.Empty(t, e.Metrics)
 	assert.NotNil(t, e.Inventory)
 	assert.Empty(t, e.Inventory.Items())
-
 }
 
 func Test_Entity_EntityAddTag(t *testing.T) {
@@ -37,7 +35,6 @@ func Test_Entity_EntityAddTag(t *testing.T) {
 
 	_ = e.AddTag("key1", "val1")
 	assert.Len(t, e.GetMetadata(), 1, "tags should have been added to the entity")
-
 }
 
 func Test_Entity_EntityCannotAddTagWithEmptyName(t *testing.T) {
@@ -219,10 +216,10 @@ func TestEntity_AddCommonDimension(t *testing.T) {
 	tests := []struct {
 		name     string
 		commons  metric.Dimensions
-		expected *Entity
+		expected *DataSet
 	}{
 		{"empty", nil, newHostEntity()},
-		{"one entry", metric.Dimensions{"k": "v"}, &Entity{
+		{"one entry", metric.Dimensions{"k": "v"}, &DataSet{
 			CommonDimensions: Common{
 				Attributes: map[string]interface{}{
 					"k": "v",
@@ -234,7 +231,7 @@ func TestEntity_AddCommonDimension(t *testing.T) {
 			Events:    event.Events{},
 			lock:      &sync.Mutex{},
 		}},
-		{"two entries", metric.Dimensions{"k1": "v1", "k2": "v2"}, &Entity{
+		{"two entries", metric.Dimensions{"k1": "v1", "k2": "v2"}, &DataSet{
 			CommonDimensions: Common{
 				Attributes: map[string]interface{}{
 					"k1": "v1",
@@ -250,7 +247,6 @@ func TestEntity_AddCommonDimension(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got := newHostEntity()
 			for k, v := range tt.commons {
 				got.AddCommonDimension(k, v)
@@ -268,9 +264,9 @@ func TestEntity_AddCommonTimestamp(t *testing.T) {
 	tests := []struct {
 		name      string
 		timestamp time.Time
-		expected  *Entity
+		expected  *DataSet
 	}{
-		{"one entry", time.Unix(10000000, 0), &Entity{
+		{"one entry", time.Unix(10000000, 0), &DataSet{
 			CommonDimensions: Common{
 				Timestamp: asPtr(10000000),
 			},
@@ -298,9 +294,9 @@ func TestEntity_AddCommonInterval(t *testing.T) {
 	tests := []struct {
 		name     string
 		interval time.Duration
-		expected *Entity
+		expected *DataSet
 	}{
-		{"one entry", time.Duration(100000000), &Entity{
+		{"one entry", time.Duration(100000000), &DataSet{
 			CommonDimensions: Common{
 				Interval: asPtr(100),
 			},

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -50,6 +50,9 @@ type Integration struct {
 	writer       io.Writer
 	logger       log.Logger
 	args         interface{}
+
+	// DataSet contains all metrics not related to any entity.
+	DataSet *DataSet `json:"-"` // skip json serializing
 }
 
 // New creates new integration with sane default values.
@@ -100,7 +103,16 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 
 	i.HostEntity = newHostEntity()
 
+	i.DataSet = newHostEntity()
+	i.DataSet.IgnoreHostEntity = true
+
 	return
+}
+
+// AddMetric adds the metric to the default DataSet of the integration which is not associated
+// with any entity.
+func (i *Integration) AddMetric(metric metric.Metric) {
+	i.DataSet.AddMetric(metric)
 }
 
 // NewEntity method creates a new (uniquely named) Entity.


### PR DESCRIPTION
this is a quick dirty workaround to show what having an interface to add metrics not related to any entity would look like. 

IMO we should take the advantage that we are introducing some changes in the protocol to refactor the hole integration package to clearly show that the entity is not the main entry point to add metrics and even if possible i would get rid of most things related to entities since they will be synthesized in the backend. 