### PR TITLE
feat(persist): clean old entries upon loading store file

### DIFF
--- a/persist/storer.go
+++ b/persist/storer.go
@@ -54,12 +54,8 @@ type inMemoryStore struct {
 
 // Holder for any entry in the JSON storage
 type jsonEntry struct {
-	entryTimestamp `json:",inline"`
-	Value          interface{}
-}
-
-type entryTimestamp struct {
 	Timestamp int64
+	Value     interface{}
 }
 
 // fileStore is a Storer implementation that uses the file system as persistence backend, storing
@@ -177,8 +173,8 @@ func (j inMemoryStore) Set(key string, value interface{}) int64 {
 
 	ts := now().Unix()
 	j.cachedData[key] = jsonEntry{
-		entryTimestamp: entryTimestamp{ts},
-		Value:          value,
+		Timestamp: ts,
+		Value:     value,
 	}
 	return ts
 }
@@ -257,7 +253,10 @@ func (j *fileStore) deleteOldEntries() error {
 	j.locker.Lock()
 	defer j.locker.Unlock()
 
-	entry := entryTimestamp{}
+	// Just decode Timestamp for performance reasons.
+	var entry struct {
+		Timestamp int64
+	}
 
 	nowTime := now()
 

--- a/persist/storer_test.go
+++ b/persist/storer_test.go
@@ -529,7 +529,9 @@ func Benchmark_UnmashalEntireStruct(b *testing.B) {
 }
 
 func Benchmark_UnmashalPartialStruct(b *testing.B) {
-	timestamp := entryTimestamp{}
+	var timestamp struct {
+		Timestamp int64
+	}
 	for i := 0; i < b.N; i++ {
 		if err := json.Unmarshal(data, &timestamp); err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
Adds a garbage collect mechanism to remove entries from the storer file saved on disk which has been expired.
Expiration is calculated using the same `TTL`  that is being used to remove storer files and the mechanism remove the entires that has not been updated in a period greater than the `TTL`

Fixes #294 

**Context for the reviewer**:
- Storer files are created one per instance of the integration running on the host, since a hash, computed from the args, is [added to the file name](https://github.com/newrelic/infra-integrations-sdk/blob/v3/integration/integration.go#L103).
- Entries on the storer file are identified by the metric set attributes, usually entity attributes.
- The [current mechanism ](https://github.com/newrelic/infra-integrations-sdk/blob/v3/persist/store_path.go#L59)removes the hole file when it is not updated.
- The implemented mechanism remove entries that are not updated.  