### PR TITLE
Add possibility to define a custom folder for temporary files.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: UnitTesting
+
+on: [push, pull_request]
+
+env:
+  GO111MODULE: off
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/github.com/newrelic/infra-integrations-sdk
+    steps:
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/newrelic/infra-integrations-sdk
+
+      - name: Test
+        env:
+          GOPATH: "${{ github.workspace }}"
+        run: env PATH="$PATH:$GOPATH/bin" make test

--- a/args/args.go
+++ b/args/args.go
@@ -23,6 +23,7 @@ type DefaultArgumentList struct {
 	NriAddHostname bool   `default:"false" help:"Add hostname attribute to the samples."`
 	NriCluster     string `default:"" help:"Optional. Cluster name"`
 	NriService     string `default:"" help:"Optional. Service name"`
+	TempDir        string `default:"" help:"Optional. Integrations path to store temporal data (defaults to os.tempDir if left empty)."`
 }
 
 // All returns if all data should be published
@@ -81,12 +82,12 @@ func underscore(s string) string {
 // fields it defines. Each of the fields in the struct can define their defaults
 // and help string by using tags:
 //
-//  type Arguments struct {
-//     	DefaultArgumentList
-//     	Argument1 bool   `default:"false" help:"This is the help we will print"`
-//     	Argument2 int    `default:"1" help:"This is the help we will print"`
-//     	Argument3 string `default:"value" help:"This is the help we will print"`
-//  }
+//	type Arguments struct {
+//	   	DefaultArgumentList
+//	   	Argument1 bool   `default:"false" help:"This is the help we will print"`
+//	   	Argument2 int    `default:"1" help:"This is the help we will print"`
+//	   	Argument3 string `default:"value" help:"This is the help we will print"`
+//	}
 //
 // The fields in the struct will be populated with the values set either from
 // the command line or from environment variables.

--- a/data/metric/metrics_test.go
+++ b/data/metric/metrics_test.go
@@ -130,7 +130,7 @@ func TestSet_SetMetricsRatesAndDeltas(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(string(tc.sourceType), func(t *testing.T) {
+		t.Run(tc.sourceType.String(), func(t *testing.T) {
 
 			persist.SetNow(growingTime)
 
@@ -145,7 +145,7 @@ func TestSet_SetMetricsRatesAndDeltas(t *testing.T) {
 
 func TestSet_SetMetricPositivesThrowsOnNegativeValues(t *testing.T) {
 	for _, sourceType := range []SourceType{PDELTA, PRATE} {
-		t.Run(string(sourceType), func(t *testing.T) {
+		t.Run(sourceType.String(), func(t *testing.T) {
 			persist.SetNow(growingTime)
 			ms := NewSet(
 				"some-event-type",

--- a/data/metric/source_type_test.go
+++ b/data/metric/source_type_test.go
@@ -25,7 +25,7 @@ func TestSourceType_Positive(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(string(tc.sourceType), func(t *testing.T) {
+		t.Run(tc.sourceType.String(), func(t *testing.T) {
 			assert.Equal(t, tc.isPositive, tc.sourceType.IsPositive())
 		})
 	}

--- a/docs/toolset/args.md
+++ b/docs/toolset/args.md
@@ -34,6 +34,7 @@ consider. All of them are `bool` and default to `false`. They are described foll
 * `NriAddHostname`: if true, agent will decorate all the metrics with the `hostname`.
 * `NriCluster`: if any value is provided, all the metrics will be decorated with `clusterName: value`. 
 * `NriService`: if any value is provided, all the metrics will be decorated with `serviceName: value`. 
+* `TempDir`: Integrations path to store temporal data (it defaults to `os.TempDir()` if it's left empty). 
 
 An example of
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -100,7 +100,7 @@ func New(name, version string, opts ...Option) (i *Integration, err error) {
 	}
 
 	if i.storer == nil {
-		storePath, err := persist.NewStorePath(i.Name, i.CreateUniqueID(), i.logger, persist.DefaultTTL)
+		storePath, err := persist.NewStorePath(i.Name, i.CreateUniqueID(), defaultArgs.TempDir, i.logger, persist.DefaultTTL)
 		if err != nil {
 			return nil, fmt.Errorf("can't create temporary directory for store: %s", err)
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -464,7 +464,7 @@ func TestIntegration_CreateUniqueID_Default(t *testing.T) {
 	i, err := New("testIntegration", "0.0.0", Args(&al))
 	assert.NoError(t, err)
 
-	assert.Equal(t, i.CreateUniqueID(), "3071eb6863e28435e6c7e0c2bbe55ecd")
+	assert.Equal(t, i.CreateUniqueID(), "f2fbf79d935a14908cb886e98cff0879")
 }
 
 func TestIntegration_CreateUniqueID_EnvironmentVar(t *testing.T) {
@@ -481,7 +481,7 @@ func TestIntegration_CreateUniqueID_EnvironmentVar(t *testing.T) {
 	i, err := New("testIntegration", "0.0.0", Args(&al))
 	assert.NoError(t, err)
 
-	assert.Equal(t, i.CreateUniqueID(), "2d998100982b7de9b4e446c85c3bed78")
+	assert.Equal(t, i.CreateUniqueID(), "3d3c4d31fdec9ccd1250c9d080ca514f")
 }
 
 type testWriter struct {

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -72,7 +72,7 @@ func TestItStoresOnDiskByDefault(t *testing.T) {
 	assert.NoError(t, i.Publish())
 
 	// assert data has been flushed to disk
-	storePath, err := persist.NewStorePath(i.Name, i.CreateUniqueID(), i.logger, persist.DefaultTTL)
+	storePath, err := persist.NewStorePath(i.Name, i.CreateUniqueID(), "", i.logger, persist.DefaultTTL)
 	assert.NoError(t, err)
 
 	c, err := persist.NewFileStore(storePath.GetFilePath(), log.NewStdErr(true), persist.DefaultTTL)

--- a/jmx/jmx_test.go
+++ b/jmx/jmx_test.go
@@ -123,8 +123,6 @@ func TestQuery_WithSSL(t *testing.T) {
 }
 
 func TestOpen_WithNrjmx(t *testing.T) {
-	defer Close()
-
 	aux := os.Getenv("NR_JMX_TOOL")
 	require.NoError(t, os.Unsetenv("NR_JMX_TOOL"))
 
@@ -242,14 +240,14 @@ func Test_DefaultPath_IsCorrectForOs(t *testing.T) {
 }
 
 func TestHostName(t *testing.T) {
-	defer Close()
+	cmd = nil
 	host := "a-host"
 	assert.NoError(t, OpenNoAuth(host, ""))
 	assert.Equal(t, host, HostName())
 }
 
 func TestPort(t *testing.T) {
-	defer Close()
+	cmd = nil
 	port := "6666"
 	assert.NoError(t, OpenNoAuth("", port))
 	assert.Equal(t, port, Port())

--- a/persist/store_path.go
+++ b/persist/store_path.go
@@ -28,7 +28,7 @@ type storePath struct {
 }
 
 // NewStorePath create a new instance of StorePath
-func NewStorePath(integrationName, integrationID string, ilog log.Logger, ttl time.Duration) (StorePath, error) {
+func NewStorePath(integrationName, integrationID, customTempDir string, ilog log.Logger, ttl time.Duration) (StorePath, error) {
 	if integrationName == "" {
 		return nil, fmt.Errorf("integration name not specified")
 	}
@@ -42,7 +42,7 @@ func NewStorePath(integrationName, integrationID string, ilog log.Logger, ttl ti
 	}
 
 	return &storePath{
-		dir:             tmpIntegrationDir(),
+		dir:             tmpIntegrationDir(customTempDir),
 		integrationName: integrationName,
 		integrationID:   integrationID,
 		ilog:            ilog,

--- a/persist/storer.go
+++ b/persist/storer.go
@@ -77,17 +77,21 @@ func SetNow(newNow func() time.Time) {
 // DefaultPath returns a default folder/filename dir to a Storer for an integration from the given name. The name of
 // the file will be the name of the integration with the .json extension.
 func DefaultPath(integrationName string) string {
-	dir := tmpIntegrationDir()
+	dir := tmpIntegrationDir("")
 	file := filepath.Join(dir, integrationName+".json")
 
 	return file
 }
 
-func tmpIntegrationDir() string {
-	dir := filepath.Join(os.TempDir(), integrationsDir)
+func tmpIntegrationDir(tempDir string) string {
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+
+	dir := filepath.Join(tempDir, integrationsDir)
 	// Create integrations Storer directory
 	if os.MkdirAll(dir, dirFilePerm) != nil {
-		dir = os.TempDir()
+		dir = tempDir
 	}
 	return dir
 }


### PR DESCRIPTION
Add argument to define a custom folder for temporary files.

```Go
TempDir        string `default:"" help:"Optional. Integrations path to store temporal data (defaults to os.tempDir if left empty)."`
```