### PR TITLE
Honor storer envvar (NR-302384)

### DIFF
--- a/persist/storer.go
+++ b/persist/storer.go
@@ -95,6 +95,12 @@ func TmpPath(tempDir, integrationName string) string {
 // "nr-integrations" as a subfolder, Linux example: "/tmp/nr-integrations"
 func tmpIntegrationDir(tempDir string) string {
 	dir := tempDir
+
+	legacyCachePath := os.Getenv("NRIA_CACHE_PATH")
+	if legacyCachePath != "" {
+		tempDir = legacyCachePath
+	}
+
 	if tempDir == "" {
 		tempDir = os.TempDir()
 		dir = filepath.Join(tempDir, integrationsDir)


### PR DESCRIPTION
There a some integrations ([apache](https://github.com/newrelic/nri-apache/pull/132),  [cassandra](https://github.com/newrelic/nri-cassandra/pull/205), [nginx](https://github.com/newrelic/nri-nginx/pull/161), ...) that had a custom storer implementation.

This PR honors back that legacy behavior ins case there is any customer using that feature.